### PR TITLE
Patch to support all 99 tpc-ds queries (for hive, at least)

### DIFF
--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -60,6 +60,15 @@ public class AggregatedRelation extends ExactRelation {
         subquery = true;
     }
 
+    // Copy constructor.
+    public AggregatedRelation(AggregatedRelation other) {
+        super(other.vc);
+        this.name = other.name;
+        this.source = other.source;
+        this.elems = other.elems;
+        this.subquery = true;
+    }
+
     @Override
     protected String getSourceName() {
         return getAlias();
@@ -248,6 +257,11 @@ public class AggregatedRelation extends ExactRelation {
     public ColNameExpr partitionColumn() {
         ColNameExpr col = new ColNameExpr(vc, partitionColumnName(), getAlias());
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return elems;
     }
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxSetRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxSetRelation.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.umich.verdict.relation;
+
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.relation.expr.*;
+
+import java.util.*;
+
+/**
+ * Created by Dong Young Yoon on 4/3/18.
+ */
+public class ApproxSetRelation extends ApproxRelation {
+
+    private ApproxRelation source1;
+    private ApproxRelation source2;
+    private SetRelation.SetType type;
+
+    public ApproxSetRelation(VerdictContext vc, ApproxRelation source1, ApproxRelation source2,
+                             SetRelation.SetType type) {
+        super(vc);
+        this.source1 = source1;
+        this.source2 = source2;
+        this.type = type;
+    }
+
+    private String getSetTypeString() {
+        switch (type) {
+            case UNION_ALL:
+                return "UNION ALL";
+            case UNION:
+                return "UNION";
+            case EXCEPT:
+                return "EXCEPT";
+            case INTERSECT:
+                return "INTERSECT";
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+    @Override
+    public ExactRelation rewriteForPointEstimate() {
+        ExactRelation s = new SetRelation(vc, source1.rewriteForPointEstimate(),
+                source2.rewriteForPointEstimate(),
+                type);
+        s.setAlias(getAlias());
+        return s;
+    }
+
+    @Override
+    protected ExactRelation rewriteWithPartition() {
+        ExactRelation newSource1 = source1.rewriteWithPartition();
+        ExactRelation newSource2 = source2.rewriteWithPartition();
+
+        SetRelation s = new SetRelation(vc, newSource1, newSource2, type);
+        s.setAlias(getAlias());
+        return s;
+    }
+
+    @Override
+    protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+        List<Expr> expr1 = source1.samplingProbabilityExprsFor(f);
+        List<Expr> expr2 = source2.samplingProbabilityExprsFor(f);
+        expr1.addAll(expr2);
+        return expr1;
+    }
+
+    @Override
+    public double samplingProbability() {
+        switch (type) {
+            // For now, let's say that UNION ALL and UNION are roughly same.
+            case UNION_ALL:
+            case UNION:
+                return source1.samplingProbability() + source2.samplingProbability();
+            case EXCEPT:
+                // This is not true... need to revise it later.
+                return source1.samplingProbability();
+            case INTERSECT:
+                return source1.samplingProbability() * source2.samplingProbability();
+            default:
+                return 0;
+        }
+    }
+
+    @Override
+    public double cost() {
+        return source1.cost() + source2.cost();
+    }
+
+    @Override
+    public Expr tupleProbabilityColumn() {
+        Expr expr1 = source1.tupleProbabilityColumn();
+        Expr expr2 = source2.tupleProbabilityColumn();
+
+        switch (type) {
+            // For now, let's say that UNION ALL and UNION are roughly same.
+            case UNION_ALL:
+            case UNION:
+                return new BinaryOpExpr(vc, expr1, expr2, "+");
+            case EXCEPT:
+                // This is not true... need to revise it later.
+                return expr1;
+            case INTERSECT:
+                return new BinaryOpExpr(vc, expr1, expr2, "*");
+            default:
+                return expr1;
+        }
+    }
+
+    @Override
+    public Expr tableSamplingRatio() {
+        Expr expr1 = source1.tableSamplingRatio();
+        Expr expr2 = source2.tableSamplingRatio();
+        Expr combined = new BinaryOpExpr(vc, expr1, expr2, "*");
+        return combined;
+    }
+
+    @Override
+    public String sampleType() {
+        return source1.sampleType() + "-" + source2.sampleType();
+    }
+
+    @Override
+    protected List<String> getColumnsOnWhichSamplesAreCreated() {
+        return Arrays.asList();
+    }
+
+    @Override
+    protected Map<TableUniqueName, String> tableSubstitution() {
+        Map<TableUniqueName, String> sub1 = source1.tableSubstitution();
+        Map<TableUniqueName, String> sub2 = source2.tableSubstitution();
+
+        HashMap<TableUniqueName, String> m = new HashMap<TableUniqueName, String>();
+        m.putAll(sub1);
+        m.putAll(sub2);
+        return m;
+    }
+
+    @Override
+    protected boolean doesIncludeSample() {
+        return source1.doesIncludeSample() || source2.doesIncludeSample();
+    }
+
+    @Override
+    public boolean equals(ApproxRelation o) {
+        if (o instanceof ApproxSetRelation) {
+            ApproxSetRelation s = (ApproxSetRelation) o;
+           if (source1.equals(s.source1) && source2.equals(s.source2)) {
+               if (type == s.type) {
+                   return true;
+               }
+           }
+        }
+        return false;
+    }
+
+    @Override
+    protected String toStringWithIndent(String indent) {
+        StringBuilder s = new StringBuilder(1000);
+        s.append(indent);
+        s.append(String.format("%s(%s) [%s], sample type: %s (%s), sampling prob: %f, cost: %f\n",
+                this.getClass().getSimpleName(), getAlias(), getSetTypeString(), sampleType(),
+                getColumnsOnWhichSamplesAreCreated(), samplingProbability(), cost()));
+        s.append(source1.toStringWithIndent(indent + "  "));
+        s.append(source2.toStringWithIndent(indent + "  "));
+        return s.toString();
+    }
+
+    @Override
+    public List<ColNameExpr> getAssociatedColumnNames(TableNameExpr tabExpr) {
+        List<ColNameExpr> colnames = new ArrayList<>();
+        colnames.addAll(source1.getAssociatedColumnNames(tabExpr));
+        colnames.addAll(source2.getAssociatedColumnNames(tabExpr));
+        return colnames;
+    }
+}

--- a/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import edu.umich.verdict.relation.expr.*;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.base.Optional;
@@ -31,10 +32,6 @@ import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.condition.CompCond;
 import edu.umich.verdict.relation.condition.Cond;
 import edu.umich.verdict.relation.condition.CondModifier;
-import edu.umich.verdict.relation.expr.ColNameExpr;
-import edu.umich.verdict.relation.expr.Expr;
-import edu.umich.verdict.relation.expr.ExprModifier;
-import edu.umich.verdict.relation.expr.SubqueryExpr;
 import edu.umich.verdict.util.VerdictLogger;
 
 public class FilteredRelation extends ExactRelation {
@@ -147,6 +144,11 @@ public class FilteredRelation extends ExactRelation {
         ColNameExpr col = source.partitionColumn();
         // col.setTab(getAliasName());
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return source.getSelectElemList();
     }
 
     // @Override

--- a/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import edu.umich.verdict.relation.expr.SelectElem;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.base.Joiner;
@@ -167,6 +168,11 @@ public class GroupedRelation extends ExactRelation {
     public ColNameExpr partitionColumn() {
         ColNameExpr col = source.partitionColumn();
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return source.getSelectElemList();
     }
 
     // @Override

--- a/core/src/main/java/edu/umich/verdict/relation/LateralViewRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LateralViewRelation.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import edu.umich.verdict.relation.expr.SelectElem;
 import org.apache.commons.lang3.tuple.Pair;
 
 import edu.umich.verdict.VerdictContext;
@@ -94,6 +95,11 @@ public class LateralViewRelation extends ExactRelation {
     @Override
     public ColNameExpr partitionColumn() {
         return null;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return new ArrayList<>();
     }
 
     @Override

--- a/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
@@ -26,6 +26,7 @@ import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
+import edu.umich.verdict.relation.expr.SelectElem;
 
 public class LimitedRelation extends ExactRelation {
 
@@ -84,6 +85,11 @@ public class LimitedRelation extends ExactRelation {
         ColNameExpr col = source.partitionColumn();
         col.setTab(getAlias());
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return source.getSelectElemList();
     }
 
     @Override

--- a/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
@@ -28,6 +28,7 @@ import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
+import edu.umich.verdict.relation.expr.SelectElem;
 
 public class OrderedRelation extends ExactRelation {
 
@@ -112,6 +113,11 @@ public class OrderedRelation extends ExactRelation {
         ColNameExpr col = source.partitionColumn();
         col.setTab(getAlias());
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return source.getSelectElemList();
     }
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
@@ -46,6 +46,14 @@ public class ProjectedRelation extends ExactRelation {
         this.elems = elems;
     }
 
+    // Copy constructor.
+    public ProjectedRelation(ProjectedRelation other) {
+        super(other.vc);
+        this.name = other.name;
+        this.source = other.source;
+        this.elems = other.elems;
+    }
+
     // public static ProjectedRelation from(VerdictContext vc, AggregatedRelation r)
     // {
     // List<SelectElem> selectElems = new ArrayList<SelectElem>();
@@ -283,6 +291,11 @@ public class ProjectedRelation extends ExactRelation {
         col.setTab(getAlias());
 
         return col;
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return elems;
     }
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SetRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SetRelation.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.umich.verdict.relation;
+
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.datatypes.SampleParam;
+import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.Expr;
+import edu.umich.verdict.relation.expr.SelectElem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Dong Young Yoon on 4/2/18.
+ */
+public class SetRelation extends ExactRelation {
+
+    private ExactRelation source1;
+    private ExactRelation source2;
+    private SetType type;
+
+    public enum SetType {UNION_ALL, UNION, EXCEPT, INTERSECT, UNKNOWN}
+
+    public SetRelation(VerdictContext vc, ExactRelation source1, ExactRelation source2,
+                          SetRelation.SetType type) {
+        super(vc);
+        this.source1 = source1;
+        this.source2 = source2;
+        this.type = type;
+    }
+
+    public SetRelation(SetRelation other) {
+        super(other.vc);
+        this.source1 = other.source1;
+        this.source2 = other.source2;
+        this.type = other.type;
+        this.name = other.name;
+    }
+
+    public ExactRelation getLeftSource() {
+        return source1;
+    }
+
+    public ExactRelation getRightSource() {
+        return source2;
+    }
+
+    public SetType getSetType() {
+        return type;
+    }
+
+    private String getSetTypeString() {
+        switch (type) {
+            case UNION_ALL:
+                return "UNION ALL";
+            case UNION:
+                return "UNION";
+            case EXCEPT:
+                return "EXCEPT";
+            case INTERSECT:
+                return "INTERSECT";
+            case UNKNOWN:
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+    @Override
+    protected String getSourceName() {
+        return getAlias();
+    }
+
+    @Override
+    public ApproxRelation approx() throws VerdictException {
+        ApproxRelation a = new ApproxSetRelation(vc, source1.approx(), source2.approx(), type);
+        a.setAlias(getAlias());
+        return a;
+    }
+
+    @Override
+    protected ApproxRelation approxWith(Map<TableUniqueName, SampleParam> replace) {
+        ApproxRelation a = new ApproxSetRelation(vc, source1.approxWith(replace),
+                source2.approxWith(replace),
+                type);
+        a.setAlias(getAlias());
+        return a;
+    }
+
+    @Override
+    protected List<ApproxRelation> nBestSamples(Expr elem, int n) throws VerdictException {
+        // Now it simply follows the implementation from JoinedRelation.
+        List<ApproxRelation> ofSources1 = source1.nBestSamples(elem, n);
+        List<ApproxRelation> ofSources2 = source2.nBestSamples(elem, n);
+        List<ApproxRelation> sets = new ArrayList<>();
+
+        for (ApproxRelation a1 : ofSources1) {
+            for (ApproxRelation a2 : ofSources2) {
+                ApproxSetRelation s = new ApproxSetRelation(vc, a1, a2, type);
+                sets.add(s);
+            }
+        }
+        return sets;
+    }
+
+    @Override
+    public ColNameExpr partitionColumn() {
+        // Now it simply follows the implementation from JoinedRelation.
+        ColNameExpr col1 = source1.partitionColumn();
+        if (col1 != null) {
+            return col1;
+        } else {
+            ColNameExpr col2 = source2.partitionColumn();
+            return col2;
+        }
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        List<SelectElem> selectList = source1.getSelectElemList();
+        selectList.addAll(source2.getSelectElemList());
+        return selectList;
+    }
+
+    @Override
+    public List<ColNameExpr> accumulateSamplingProbColumns() {
+        // Again, same implementation from JoinedRelation.
+        List<ColNameExpr> union = new ArrayList<>(source1.accumulateSamplingProbColumns());
+        union.addAll(source2.accumulateSamplingProbColumns());
+        return union;
+    }
+
+    @Override
+    protected String toStringWithIndent(String indent) {
+        StringBuilder s = new StringBuilder(1000);
+        s.append(indent);
+        s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAlias(),
+                this.getSetTypeString()));
+        s.append(source1.toStringWithIndent(indent + "  "));
+        s.append(source2.toStringWithIndent(indent + "  "));
+        return s.toString();
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sql = new StringBuilder();
+        sql.append(source1.toSql());
+        sql.append(String.format(" %s ", this.getSetTypeString()));
+        sql.append(source2.toSql());
+        return sql.toString();
+    }
+}

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import edu.umich.verdict.relation.expr.SelectElem;
 import org.apache.commons.lang3.tuple.Pair;
 
 import edu.umich.verdict.VerdictContext;
@@ -331,6 +332,11 @@ public class SingleRelation extends ExactRelation {
                     + "This is an expected behavior if this is not a sample table.");
             return null;
         }
+    }
+
+    @Override
+    public List<SelectElem> getSelectElemList() {
+        return new ArrayList<>();
     }
 
     // @Override

--- a/core/src/main/java/edu/umich/verdict/relation/expr/Expr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/Expr.java
@@ -193,6 +193,19 @@ class ExpressionGen extends VerdictSQLBaseVisitor<Expr> {
     }
 
     @Override
+    public Expr visitInterval(VerdictSQLParser.IntervalContext ctx) {
+        IntervalExpr.Unit unit = IntervalExpr.Unit.DAY;
+        if (ctx.DAY() != null || ctx.DAYS() != null) {
+            unit = IntervalExpr.Unit.DAY;
+        } else if (ctx.MONTH() != null || ctx.MONTHS() != null) {
+            unit = IntervalExpr.Unit.MONTH;
+        } else if (ctx.YEAR() != null || ctx.YEARS() != null) {
+            unit = IntervalExpr.Unit.YEAR;
+        }
+        return new IntervalExpr(vc, ctx.constant_expression().getText(), unit);
+    }
+
+    @Override
     public Expr visitPrimitive_expression(VerdictSQLParser.Primitive_expressionContext ctx) {
         return ConstantExpr.from(vc, ctx.getText());
     }

--- a/core/src/main/java/edu/umich/verdict/relation/expr/IntervalExpr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/IntervalExpr.java
@@ -1,0 +1,79 @@
+package edu.umich.verdict.relation.expr;
+
+import edu.umich.verdict.VerdictContext;
+
+/**
+ * Created by Dong Young Yoon on 4/3/18.
+ */
+public class IntervalExpr extends Expr{
+
+    private Object value;
+    private Unit unit;
+
+    public enum Unit {DAY, MONTH, YEAR}
+
+    public IntervalExpr(VerdictContext vc, Object value, Unit unit) {
+        super(vc);
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Unit getUnit() {
+        return unit;
+    }
+
+    @Override
+    public String toString() {
+        String unitStr;
+        switch (unit) {
+            case DAY:
+                unitStr = "days";
+                break;
+            case MONTH:
+                unitStr = "months";
+                break;
+            case YEAR:
+                unitStr = "years";
+                break;
+            default:
+                unitStr = "days";
+                break;
+        }
+        return String.format("interval %s %s", value.toString(), unitStr);
+    }
+
+    @Override
+    public <T> T accept(ExprVisitor<T> v) {
+        return v.call(this);
+    }
+
+    @Override
+    public Expr withTableSubstituted(String newTab) {
+        return this;
+    }
+
+    @Override
+    public String toSql() {
+        return this.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode() + unit.hashCode();
+    }
+
+    @Override
+    public boolean equals(Expr o) {
+        if (o instanceof IntervalExpr) {
+            IntervalExpr other = (IntervalExpr) o;
+            if (this.value.toString().equals(other.value.toString()) && this.unit == other.unit) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/edu/umich/verdict/util/StringManipulations.java
+++ b/core/src/main/java/edu/umich/verdict/util/StringManipulations.java
@@ -19,6 +19,7 @@ package edu.umich.verdict.util;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.antlr.runtime.BaseRecognizer;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 
@@ -28,6 +29,7 @@ import edu.umich.verdict.VerdictJDBCContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.parser.VerdictSQLLexer;
 import edu.umich.verdict.parser.VerdictSQLParser;
+import org.antlr.v4.runtime.Token;
 
 public class StringManipulations {
 


### PR DESCRIPTION
This pull request contains various fixes for VerdictDB parser to support all 99 tpc-ds queries.
Note that 99 sample tpc-ds queries from [hive-testbench](https://github.com/hortonworks/hive-testbench) were used for test, and thus applying this patch does not necessarily mean that VerdictDB now supports all 99 tpc-ds queries written for **any** database. 

Also note that this patch only ensures tpc-ds queries are parsed into VerdictDB's parse trees without getting errors. There is not any guarantee that the generated parse trees are correct (i.e., yield expected/same result when used to rewrite SQL with/without samples) yet.

I will leave this pull request for a possible review and probably merge early next week.

The following is the list of changes made in this pull request:
1. added support for set operation (i.e., UNION ALL, UNION, EXCEPT, and INTERSECT).
2. added support for 'INTERVAL <numbers> day/month/year' function/operator for date/time.
3. added support for '||' binary operator (used for a string concatenation in some DBs).
4. added support for 'GROUP BY ROLLUP' clause (which is different from GROUP BY ... WITH ROLLUP).
5. added support for 'LEFT SEMI JOIN' clause, which is available in Hive.
6. added support for parsing COALESCE function.
7. fixed a bug where some keywords cannot be used as an identifier (e.g., YEAR, STORE, etc.).
8. added support for subqueries defined by WITH clause.
9. added support for identifying inner joins in WHERE clause defined by simple "BinaryOp = BinaryOp" with columns and constants (e.g., col1 + 13 = col2 - 10).
10. added support for RANK, DENSE_RANK, NTILE, ROW_NUMBER functions.
11. added support for ORDER BY clause in OVER clause.