### PR TITLE
Added env variable flag for packaging and deploying

### DIFF
--- a/.circleci/check_jdbc_driver_name.sh
+++ b/.circleci/check_jdbc_driver_name.sh
@@ -10,7 +10,7 @@ verdictdb_version=${verdictdb_version%$"</version>"}
 #echo "${verdictdb_version}"
 
 # Package
-mvn -DskipTests -Dverdictdb-packaging=true package
+mvn -DskipTests -DtestPhase=false -DpackagePhase=true package
 
 # Unzip the packaged file
 JAR_FILE_NAME=target/verdictdb-core-${verdictdb_version}-jar-with-dependencies.jar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://circleci.com/gh/mozafari/verdictdb/tree/master.svg?style=shield&circle-token=16a7386340ff7022b21ce007434f8caa2fa97aec)](https://circleci.com/gh/mozafari/verdictdb/tree/master)
 [![Code Coverage](https://codecov.io/gh/mozafari/verdictdb/branch/master/graph/badge.svg)](https://codecov.io/gh/mozafari/verdictdb)
 
+July 25 2018: The current documentation is out of date; it will be updated in a few days.
+
 # Same SQL, Same DB, 100x-200x Faster Analytics
 
 <p align="center">

--- a/docs/docs/getting_started/install.md
+++ b/docs/docs/getting_started/install.md
@@ -1,1 +1,2 @@
 # Installation
+

--- a/pom.xml
+++ b/pom.xml
@@ -148,23 +148,6 @@
                     <check/>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven.assembly-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -362,12 +345,67 @@
             </build>
         </profile>
         <profile>
-            <id>testing-stage</id>
+            <id>assemble-dependencies</id>
+            <activation>
+                <property>
+                    <name>packagePhase</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven.assembly-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>assemble-no-dependencies</id>
+            <activation>
+                <property>
+                    <name>deployPhase</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven.assembly-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>spark-compile</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
                 <property>
-                    <name>verdictdb-packaging</name>
-                    <value>!true</value>
+                    <name>testPhase</name>
+                    <value>true</value>
                 </property>
             </activation>
             <dependencies>
@@ -414,10 +452,10 @@
             </dependencies>
         </profile>
         <profile>
-            <id>packaging-stage</id>
+            <id>spark-provided</id>
             <activation>
                 <property>
-                    <name>verdictdb-packaging</name>
+                    <name>packagePhase</name>
                     <value>true</value>
                 </property>
             </activation>
@@ -445,6 +483,12 @@
         </profile>
         <profile>
             <id>sonatype-release</id>
+            <activation>
+                <property>
+                    <name>deployPhase</name>
+                    <value>true</value>
+                </property>
+            </activation>
             <distributionManagement>
                 <snapshotRepository>
                     <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.verdictdb</groupId>
     <artifactId>verdictdb-core</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.1</version>
+    <version>0.5.2-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Platform-independent data analytics system for interactive-speed analytics</description>
     <url>http://verdictdb.org</url>
@@ -64,8 +64,12 @@
     </developers>
 
     <properties>
+        <!-- one of the following three phases may be chosen -->
+        <testPhase>true</testPhase>
+        <packagePhase>false</packagePhase>
+        <deployPhase>false</deployPhase>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <antlr4.visitor>true</antlr4.visitor>
         <antlr4.version>4.5.3</antlr4.version>
         <apache.commons.version>3.5</apache.commons.version>
         <junit.version>4.12</junit.version>
@@ -374,7 +378,7 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
+        <!-- <profile>
             <id>assemble-no-dependencies</id>
             <activation>
                 <property>
@@ -398,7 +402,7 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
+        </profile> -->
         <profile>
             <id>spark-compile</id>
             <activation>
@@ -455,8 +459,8 @@
             <id>spark-provided</id>
             <activation>
                 <property>
-                    <name>packagePhase</name>
-                    <value>true</value>
+                    <name>testPhase</name>
+                    <value>!true</value>
                 </property>
             </activation>
             <dependencies>

--- a/src/main/java/org/verdictdb/jdbc41/Driver.java
+++ b/src/main/java/org/verdictdb/jdbc41/Driver.java
@@ -57,7 +57,7 @@ public class Driver implements java.sql.Driver {
           newUrl = Joiner.on(":").join(newTokens);
         }
         Connection verdictConnection = new org.verdictdb.jdbc41.VerdictConnection(newUrl, info);
-        System.out.println("VerdictConnection has been created: " + verdictConnection);
+        // System.out.println("VerdictConnection has been created: " + verdictConnection);
         return verdictConnection;
       } catch (VerdictDBDbmsException e) {
         e.printStackTrace();


### PR DESCRIPTION
A new set of build commands are summarized here: https://github.com/mozafari/verdictdb/wiki/Build-commands

The existing "mvn test" command is unaffected since it is the default option.

I updated the version to "0.5.2-SNAPSHOT" since 0.5.1 is out.