### PR TITLE
Added logger implementation based on logback + slf4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,26 +185,6 @@
             <version>${google.guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.6.5</version>
@@ -213,6 +193,11 @@
             <groupId>uk.com.robust-it</groupId>
             <artifactId>cloning</artifactId>
             <version>1.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
 
         <!-- test supports -->

--- a/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
+++ b/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
@@ -16,4 +16,340 @@
 
 package org.verdictdb.commons;
 
-public class VerdictDBLogger {}
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+public class VerdictDBLogger implements org.slf4j.Logger {
+
+  private Logger logger;
+
+  private VerdictDBLogger(Logger logger) {
+    this.logger = logger;
+  }
+
+  public static VerdictDBLogger getLogger(Class<?> c) {
+    return new VerdictDBLogger((Logger) LoggerFactory.getLogger(c));
+  }
+
+  public static VerdictDBLogger getLogger(String name) {
+    return new VerdictDBLogger((Logger) LoggerFactory.getLogger(name));
+  }
+
+  public void setLevel(Level level) {
+    logger.setLevel(level);
+  }
+
+  public void addAppender(Appender<ILoggingEvent> appender) {
+    appender.setContext(logger.getLoggerContext());
+    logger.addAppender(appender);
+  }
+
+  @Override
+  public String getName() {
+    return logger.getName();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  @Override
+  public void trace(String s) {
+    logger.trace(s);
+  }
+
+  @Override
+  public void trace(String s, Object o) {
+    logger.trace(s,o);
+  }
+
+  @Override
+  public void trace(String s, Object o, Object o1) {
+    logger.trace(s, o, o1);
+  }
+
+  @Override
+  public void trace(String s, Object... objects) {
+    logger.trace(s, objects);
+  }
+
+  @Override
+  public void trace(String s, Throwable throwable) {
+    logger.trace(s, throwable);
+  }
+
+  @Override
+  public boolean isTraceEnabled(Marker marker) {
+    return logger.isTraceEnabled(marker);
+  }
+
+  @Override
+  public void trace(Marker marker, String s) {
+    logger.trace(marker, s);
+  }
+
+  @Override
+  public void trace(Marker marker, String s, Object o) {
+    logger.trace(marker, s, o);
+  }
+
+  @Override
+  public void trace(Marker marker, String s, Object o, Object o1) {
+    logger.trace(marker, s, o, o1);
+  }
+
+  @Override
+  public void trace(Marker marker, String s, Object... objects) {
+    logger.trace(marker, s, objects);
+  }
+
+  @Override
+  public void trace(Marker marker, String s, Throwable throwable) {
+    logger.trace(marker, s, throwable);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override
+  public void debug(String s) {
+    logger.debug(s);
+  }
+
+  @Override
+  public void debug(String s, Object o) {
+    logger.debug(s, o);
+  }
+
+  @Override
+  public void debug(String s, Object o, Object o1) {
+    logger.debug(s, o, o1);
+  }
+
+  @Override
+  public void debug(String s, Object... objects) {
+    logger.debug(s, objects);
+  }
+
+  @Override
+  public void debug(String s, Throwable throwable) {
+    logger.debug(s, throwable);
+  }
+
+  @Override
+  public boolean isDebugEnabled(Marker marker) {
+    return logger.isDebugEnabled(marker);
+  }
+
+  @Override
+  public void debug(Marker marker, String s) {
+    logger.debug(marker, s);
+  }
+
+  @Override
+  public void debug(Marker marker, String s, Object o) {
+    logger.debug(marker, s, o);
+  }
+
+  @Override
+  public void debug(Marker marker, String s, Object o, Object o1) {
+    logger.debug(marker, s, o, o1);
+  }
+
+  @Override
+  public void debug(Marker marker, String s, Object... objects) {
+    logger.debug(marker, s, objects);
+  }
+
+  @Override
+  public void debug(Marker marker, String s, Throwable throwable) {
+    logger.debug(marker, s, throwable);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  @Override
+  public void info(String s) {
+    logger.info(s);
+  }
+
+  @Override
+  public void info(String s, Object o) {
+    logger.info(s, o);
+  }
+
+  @Override
+  public void info(String s, Object o, Object o1) {
+    logger.info(s, o, o1);
+  }
+
+  @Override
+  public void info(String s, Object... objects) {
+    logger.info(s, objects);
+  }
+
+  @Override
+  public void info(String s, Throwable throwable) {
+    logger.info(s, throwable);
+  }
+
+  @Override
+  public boolean isInfoEnabled(Marker marker) {
+    return logger.isInfoEnabled(marker);
+  }
+
+  @Override
+  public void info(Marker marker, String s) {
+    logger.info(marker, s);
+  }
+
+  @Override
+  public void info(Marker marker, String s, Object o) {
+    logger.info(marker, s, o);
+  }
+
+  @Override
+  public void info(Marker marker, String s, Object o, Object o1) {
+    logger.info(marker, s, o, o1);
+  }
+
+  @Override
+  public void info(Marker marker, String s, Object... objects) {
+    logger.info(marker, s, objects);
+  }
+
+  @Override
+  public void info(Marker marker, String s, Throwable throwable) {
+    logger.info(marker, s, throwable);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+
+  @Override
+  public void warn(String s) {
+    logger.warn(s);
+  }
+
+  @Override
+  public void warn(String s, Object o) {
+    logger.warn(s, o);
+  }
+
+  @Override
+  public void warn(String s, Object... objects) {
+    logger.warn(s, objects);
+  }
+
+  @Override
+  public void warn(String s, Object o, Object o1) {
+    logger.warn(s, o, o1);
+  }
+
+  @Override
+  public void warn(String s, Throwable throwable) {
+    logger.warn(s, throwable);
+  }
+
+  @Override
+  public boolean isWarnEnabled(Marker marker) {
+    return logger.isWarnEnabled();
+  }
+
+  @Override
+  public void warn(Marker marker, String s) {
+    logger.warn(marker, s);
+  }
+
+  @Override
+  public void warn(Marker marker, String s, Object o) {
+    logger.warn(marker, s, o);
+  }
+
+  @Override
+  public void warn(Marker marker, String s, Object o, Object o1) {
+    logger.warn(marker, s, o, o1);
+  }
+
+  @Override
+  public void warn(Marker marker, String s, Object... objects) {
+    logger.warn(marker, s, objects);
+  }
+
+  @Override
+  public void warn(Marker marker, String s, Throwable throwable) {
+    logger.warn(marker, s, throwable);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+
+  @Override
+  public void error(String s) {
+    logger.error(s);
+  }
+
+  @Override
+  public void error(String s, Object o) {
+    logger.error(s, o);
+  }
+
+  @Override
+  public void error(String s, Object o, Object o1) {
+    logger.error(s, o, o1);
+  }
+
+  @Override
+  public void error(String s, Object... objects) {
+    logger.error(s, objects);
+  }
+
+  @Override
+  public void error(String s, Throwable throwable) {
+    logger.error(s, throwable);
+  }
+
+  @Override
+  public boolean isErrorEnabled(Marker marker) {
+    return logger.isErrorEnabled(marker);
+  }
+
+  @Override
+  public void error(Marker marker, String s) {
+    logger.error(marker, s);
+  }
+
+  @Override
+  public void error(Marker marker, String s, Object o) {
+    logger.error(marker, s, o);
+  }
+
+  @Override
+  public void error(Marker marker, String s, Object o, Object o1) {
+    logger.error(marker, s, o, o1);
+  }
+
+  @Override
+  public void error(Marker marker, String s, Object... objects) {
+    logger.error(marker, s, objects);
+  }
+
+  @Override
+  public void error(Marker marker, String s, Throwable throwable) {
+    logger.error(marker, s, throwable);
+  }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+    </appender>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <logger name="org.verdictdb" level="TRACE"/>
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+

--- a/src/test/java/org/verdictdb/commons/VerdictDBLoggerTest.java
+++ b/src/test/java/org/verdictdb/commons/VerdictDBLoggerTest.java
@@ -1,0 +1,58 @@
+package org.verdictdb.commons;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Dong Young Yoon on 7/25/18.
+ */
+public class VerdictDBLoggerTest {
+
+  @Test
+  public void loggerTest() {
+    final VerdictDBLogger logger = VerdictDBLogger.getLogger(this.getClass());
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.setName("testAppender");
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.TRACE);
+    logger.debug("debug test");
+    logger.error("error test");
+    logger.info("info test");
+    logger.trace("trace test");
+    logger.warn("warn test");
+
+    List<ILoggingEvent> events = appender.list;
+
+    assertEquals(Level.DEBUG, events.get(0).getLevel());
+    assertEquals("debug test", events.get(0).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(0).getLoggerName());
+
+    assertEquals(Level.ERROR, events.get(1).getLevel());
+    assertEquals("error test", events.get(1).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(1).getLoggerName());
+
+    assertEquals(Level.INFO, events.get(2).getLevel());
+    assertEquals("info test", events.get(2).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(2).getLoggerName());
+
+    assertEquals(Level.TRACE, events.get(3).getLevel());
+    assertEquals("trace test", events.get(3).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(3).getLoggerName());
+
+    assertEquals(Level.WARN, events.get(4).getLevel());
+    assertEquals("warn test", events.get(4).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(4).getLoggerName());
+
+    appender.stop();
+  }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+    </appender>
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Implemented VerdictDBLogger wrapper class + added a simple unit test. 
It implements slf4j's Logger interface so we can use it just like before.
Any suggestion to improve its behavior is welcomed.
I guess we can configure our logger to print log into rolling files as well as on console later.