### PR TITLE
SelectQueryCoordinator always gets the most recent ScrambleMetaSet

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -16,6 +16,20 @@
 
 package org.verdictdb;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.verdictdb.connection.CachedDbmsConnection;
+import org.verdictdb.connection.DbmsConnection;
+import org.verdictdb.connection.JdbcConnection;
+import org.verdictdb.coordinator.ExecutionContext;
+import org.verdictdb.coordinator.VerdictResultStream;
+import org.verdictdb.coordinator.VerdictSingleResult;
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.exception.VerdictDBException;
+import org.verdictdb.metastore.ScrambleMetaStore;
+import org.verdictdb.sqlsyntax.SqlSyntax;
+import org.verdictdb.sqlsyntax.SqlSyntaxList;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -24,21 +38,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.verdictdb.connection.CachedDbmsConnection;
-import org.verdictdb.connection.DbmsConnection;
-import org.verdictdb.connection.JdbcConnection;
-import org.verdictdb.coordinator.ExecutionContext;
-import org.verdictdb.coordinator.VerdictResultStream;
-import org.verdictdb.coordinator.VerdictSingleResult;
-import org.verdictdb.exception.VerdictDBDbmsException;
-import org.verdictdb.exception.VerdictDBException;
-import org.verdictdb.sqlsyntax.SqlSyntax;
-import org.verdictdb.sqlsyntax.SqlSyntaxList;
-
 public class VerdictContext {
 
   private DbmsConnection conn;
+
+  private ScrambleMetaSet scrambleMetaSet;
 
   private final String contextId;
 
@@ -53,6 +57,7 @@ public class VerdictContext {
     this.conn = new CachedDbmsConnection(conn);
     //    this.metadataProvider = new CachedMetaDataProvider(conn);
     this.contextId = RandomStringUtils.randomAlphanumeric(5);
+    this.scrambleMetaSet = ScrambleMetaStore.retrieve(conn);
   }
 
   public static VerdictContext fromJdbcConnection(Connection jdbcConn)
@@ -125,6 +130,10 @@ public class VerdictContext {
   private synchronized long getNextExecutionSerialNumber() {
     executionSerialNumber++;
     return executionSerialNumber;
+  }
+
+  public ScrambleMetaSet getScrambleMetaSet() {
+    return scrambleMetaSet;
   }
 
   private void removeExecutionContext(ExecutionContext exec) {

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -47,6 +47,8 @@ public class ExecutionContext {
 
   private VerdictContext context;
 
+  private ScrambleMetaStore metaStore;
+
   private final long serialNumber;
 
   private static final VerdictDBLogger LOG = VerdictDBLogger.getLogger(ExecutionContext.class);
@@ -68,6 +70,7 @@ public class ExecutionContext {
   public ExecutionContext(VerdictContext context, long serialNumber) {
     this.context = context;
     this.serialNumber = serialNumber;
+    this.metaStore = new ScrambleMetaStore(context.getCopiedConnection());
   }
 
   public long getExecutionContextSerialNumber() {
@@ -94,6 +97,7 @@ public class ExecutionContext {
       LOG.debug("Query type: select");
       SelectQueryCoordinator coordinator =
           new SelectQueryCoordinator(context.getCopiedConnection());
+      coordinator.setScrambleMetaSet(metaStore.retrieve());
       ExecutionResultReader reader = coordinator.process(query);
       VerdictResultStream stream = new VerdictResultStreamFromExecutionResultReader(reader, this);
       return stream;
@@ -118,7 +122,6 @@ public class ExecutionContext {
       //              scrambleQuery.getMethod()); // dyoon: size is not used atm?
 
       // Add metadata to metastore
-      ScrambleMetaStore metaStore = new ScrambleMetaStore(context.getConnection());
       metaStore.addToStore(meta);
       return null;
     } else if (queryType.equals(QueryType.set_default_schema)) {

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -47,8 +47,6 @@ public class ExecutionContext {
 
   private VerdictContext context;
 
-  private ScrambleMetaStore metaStore;
-
   private final long serialNumber;
 
   private static final VerdictDBLogger LOG = VerdictDBLogger.getLogger(ExecutionContext.class);
@@ -70,7 +68,6 @@ public class ExecutionContext {
   public ExecutionContext(VerdictContext context, long serialNumber) {
     this.context = context;
     this.serialNumber = serialNumber;
-    this.metaStore = new ScrambleMetaStore(context.getCopiedConnection());
   }
 
   public long getExecutionContextSerialNumber() {
@@ -96,8 +93,7 @@ public class ExecutionContext {
     if (queryType.equals(QueryType.select)) {
       LOG.debug("Query type: select");
       SelectQueryCoordinator coordinator =
-          new SelectQueryCoordinator(context.getCopiedConnection());
-      coordinator.setScrambleMetaSet(metaStore.retrieve());
+          new SelectQueryCoordinator(context.getCopiedConnection(), context.getScrambleMetaSet());
       ExecutionResultReader reader = coordinator.process(query);
       VerdictResultStream stream = new VerdictResultStreamFromExecutionResultReader(reader, this);
       return stream;
@@ -122,6 +118,7 @@ public class ExecutionContext {
       //              scrambleQuery.getMethod()); // dyoon: size is not used atm?
 
       // Add metadata to metastore
+      ScrambleMetaStore metaStore = new ScrambleMetaStore(context.getConnection());
       metaStore.addToStore(meta);
       return null;
     } else if (queryType.equals(QueryType.set_default_schema)) {

--- a/src/main/java/org/verdictdb/metastore/VerdictMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/VerdictMetaStore.java
@@ -18,7 +18,7 @@ package org.verdictdb.metastore;
 
 public class VerdictMetaStore {
 
-  private final String METASTORE_TABLE_NAME = "verdictdbmeta";
+  protected static final String METASTORE_TABLE_NAME = "verdictdbmeta";
 
   public String getMetaStoreTableName() {
     return METASTORE_TABLE_NAME;


### PR DESCRIPTION
It gets ScrambleMetaSet from ScrambleMetaStore via its retrieve() method before running select queries.