### PR TITLE
ExecutionContext removes all temporary tables created when terminate() is called.

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -16,13 +16,6 @@
 
 package org.verdictdb;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.verdictdb.connection.CachedDbmsConnection;
 import org.verdictdb.connection.ConcurrentJdbcConnection;
@@ -38,10 +31,17 @@ import org.verdictdb.metastore.ScrambleMetaStore;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntaxList;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
 public class VerdictContext {
 
   private DbmsConnection conn;
-  
+
   private boolean isClosed = false;
 
   private ScrambleMetaSet scrambleMetaSet;
@@ -63,9 +63,9 @@ public class VerdictContext {
   }
 
   /**
-   * This method does not support concurrent execution of queries; thus, should not be used in 
+   * This method does not support concurrent execution of queries; thus, should not be used in
    * production.
-   * 
+   *
    * @param jdbcConn
    * @return
    * @throws VerdictDBDbmsException
@@ -78,7 +78,7 @@ public class VerdictContext {
 
   /**
    * Uses a connection pool.
-   * 
+   *
    * @param jdbcConnectionString
    * @return
    * @throws SQLException
@@ -92,7 +92,7 @@ public class VerdictContext {
 
   /**
    * Uses a connection pool.
-   * 
+   *
    * @param jdbcConnectionString
    * @param info
    * @return
@@ -103,13 +103,13 @@ public class VerdictContext {
       throws SQLException, VerdictDBDbmsException {
     attemptLoadDriverClass(jdbcConnectionString);
     return new VerdictContext(ConcurrentJdbcConnection.create(jdbcConnectionString, info));
-//    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, info);
-//    return fromJdbcConnection(jdbcConn);
+    //    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, info);
+    //    return fromJdbcConnection(jdbcConn);
   }
 
   /**
    * Uses a connection pool.
-   * 
+   *
    * @param jdbcConnectionString
    * @param user
    * @param password
@@ -125,8 +125,8 @@ public class VerdictContext {
     info.setProperty("user", user);
     info.setProperty("password", password);
     return new VerdictContext(ConcurrentJdbcConnection.create(jdbcConnectionString, info));
-//    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, user, password);
-//    return fromJdbcConnection(jdbcConn);
+    //    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, user, password);
+    //    return fromJdbcConnection(jdbcConn);
   }
 
   private static void attemptLoadDriverClass(String jdbcConnectionString) {
@@ -144,12 +144,12 @@ public class VerdictContext {
   public DbmsConnection getConnection() {
     return conn;
   }
-  
+
   public void close() {
     conn.close();
     isClosed = true;
   }
-  
+
   public boolean isClosed() {
     return isClosed;
   }
@@ -188,13 +188,15 @@ public class VerdictContext {
   }
 
   private void removeExecutionContext(ExecutionContext exec) {
+    exec.terminate();
     executionContexts.remove(exec);
   }
 
   /** terminates all open execution context. */
   public void abort() {
-    // TODO Auto-generated method stub
-
+    for (ExecutionContext context : executionContexts) {
+      context.terminate();
+    }
   }
 
   public void scramble(String originalSchema, String originalTable) {}

--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -146,6 +146,7 @@ public class VerdictContext {
   }
 
   public void close() {
+    this.abort(); // terminates all ExecutionContexts first.
     conn.close();
     isClosed = true;
   }

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -62,11 +62,11 @@ public class JdbcConnection implements DbmsConnection {
     this.conn = conn;
     try {
       this.currentSchema = conn.getSchema();
-//      if (syntax instanceof PostgresqlSyntax || syntax instanceof RedshiftSyntax) {
-//        
-//      } else {
-//        this.currentSchema = conn.getCatalog();
-//      }
+      //      if (syntax instanceof PostgresqlSyntax || syntax instanceof RedshiftSyntax) {
+      //
+      //      } else {
+      //        this.currentSchema = conn.getCatalog();
+      //      }
     } catch (SQLException e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/verdictdb/coordinator/QueryContext.java
+++ b/src/main/java/org/verdictdb/coordinator/QueryContext.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright 2018 University of Michigan
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.verdictdb.coordinator;
+
+/** Created by Dong Young Yoon on 8/8/18. */
+public class QueryContext {
+  private String verdictContextId;
+  private Long executionSerialNumber;
+
+  public QueryContext(String verdictContextId, Long executionSerialNumber) {
+    this.verdictContextId = verdictContextId;
+    this.executionSerialNumber = executionSerialNumber;
+  }
+
+  public String getVerdictContextId() {
+    return verdictContextId;
+  }
+
+  public Long getExecutionSerialNumber() {
+    return executionSerialNumber;
+  }
+}

--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -104,6 +104,36 @@ public class SelectQueryCoordinator {
 
     lastQuery = selectQuery;
 
+    return reader;
+  }
+
+  public ExecutionResultReader process(String query, QueryContext context)
+      throws VerdictDBException {
+
+    SelectQuery selectQuery = standardizeQuery(query);
+
+    // make plan
+    // if the plan does not include any aggregates, it will simply be a parsed structure of the
+    // original query.
+    QueryExecutionPlan plan =
+        QueryExecutionPlanFactory.create(scratchpadSchema, scrambleMetaSet, selectQuery, context);
+
+    // convert it to an asynchronous plan
+    // if the plan does not include any aggregates, this operation should not alter the original
+    // plan.
+    QueryExecutionPlan asyncPlan = AsyncQueryExecutionPlan.create(plan);
+
+    // simplify the plan
+    //    QueryExecutionPlan simplifiedAsyncPlan = QueryExecutionPlanSimplifier.simplify(asyncPlan);
+    //    QueryExecutionPlanSimplifier.simplify2(asyncPlan);
+
+    //    asyncPlan.getRootNode().print();
+
+    // execute the plan
+    //    ExecutionResultReader reader = ExecutablePlanRunner.getResultReader(conn,
+    // simplifiedAsyncPlan);
+    ExecutionResultReader reader = ExecutablePlanRunner.getResultReader(conn, asyncPlan);
+
     lastQuery = selectQuery;
 
     return reader;

--- a/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
@@ -1,8 +1,7 @@
 package org.verdictdb.coordinator;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -14,12 +13,22 @@ import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
+import org.verdictdb.metastore.ScrambleMetaStore;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExecutionContextTest {
 
-  //lineitem has 10 blocks, orders has 3 blocks;
+  // lineitem has 10 blocks, orders has 3 blocks;
   // lineitem join orders has 12 blocks
-  final static int blockSize = 100;
+  static final int blockSize = 100;
 
   static ScrambleMetaSet meta = new ScrambleMetaSet();
 
@@ -46,33 +55,39 @@ public class ExecutionContextTest {
   public static void setupMySqlDatabase() throws SQLException, VerdictDBException {
     String mysqlConnectionString =
         String.format("jdbc:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
-    conn = DatabaseConnectionHelpers.setupMySql(
-        mysqlConnectionString, MYSQL_UESR, MYSQL_PASSWORD, MYSQL_DATABASE);
+    conn =
+        DatabaseConnectionHelpers.setupMySql(
+            mysqlConnectionString, MYSQL_UESR, MYSQL_PASSWORD, MYSQL_DATABASE);
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
 
     // Create Scramble table
-    dbmsConn.execute(String.format("DROP TABLE IF EXISTS `%s`.`lineitem_scrambled`", MYSQL_DATABASE));
+    dbmsConn.execute(
+        String.format("DROP TABLE IF EXISTS `%s`.`lineitem_scrambled`", MYSQL_DATABASE));
     dbmsConn.execute(String.format("DROP TABLE IF EXISTS `%s`.`orders_scrambled`", MYSQL_DATABASE));
 
-    ScramblingCoordinator scrambler = 
+    ScramblingCoordinator scrambler =
         new ScramblingCoordinator(dbmsConn, MYSQL_DATABASE, MYSQL_DATABASE, (long) 100);
-    ScrambleMeta meta1 = 
-        scrambler.scramble(MYSQL_DATABASE, "lineitem", MYSQL_DATABASE, "lineitem_scrambled", "uniform");
-    ScrambleMeta meta2 = 
+    ScrambleMeta meta1 =
+        scrambler.scramble(
+            MYSQL_DATABASE, "lineitem", MYSQL_DATABASE, "lineitem_scrambled", "uniform");
+    ScrambleMeta meta2 =
         scrambler.scramble(MYSQL_DATABASE, "orders", MYSQL_DATABASE, "orders_scrambled", "uniform");
     meta.addScrambleMeta(meta1);
     meta.addScrambleMeta(meta2);
+    ScrambleMetaStore store = new ScrambleMetaStore(dbmsConn);
+    store.addToStore(meta);
   }
-  
+
   @AfterClass
   public static void tearDown() throws VerdictDBDbmsException {
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
-    dbmsConn.execute(String.format("DROP TABLE IF EXISTS `%s`.`lineitem_scrambled`", MYSQL_DATABASE));
+    dbmsConn.execute(
+        String.format("DROP TABLE IF EXISTS `%s`.`lineitem_scrambled`", MYSQL_DATABASE));
     dbmsConn.execute(String.format("DROP TABLE IF EXISTS `%s`.`orders_scrambled`", MYSQL_DATABASE));
   }
 
   @Test
-  public void testSelectQuery() throws VerdictDBException {
+  public void testSelectQuery() throws VerdictDBException, SQLException {
     String sql = String.format("select avg(l_quantity) from %s.lineitem_scrambled", MYSQL_DATABASE);
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
     VerdictContext verdict = new VerdictContext(dbmsConn);
@@ -81,4 +96,67 @@ public class ExecutionContextTest {
     VerdictSingleResult result = exec.sql(sql);
   }
 
+  @Test
+  public void testTempTableExistsBeforeTerminate()
+      throws VerdictDBException, SQLException, IOException {
+    String filename = "query1.sql";
+    File file = new File("src/test/resources/tpch_test_query/" + filename);
+    String sql = Files.toString(file, Charsets.UTF_8);
+    DbmsConnection dbmsConn = JdbcConnection.create(conn);
+    ((JdbcConnection) dbmsConn).setOutputDebugMessage(true);
+    dbmsConn.setDefaultSchema(MYSQL_DATABASE);
+    VerdictContext verdict = new VerdictContext(dbmsConn);
+    ExecutionContext exec = new ExecutionContext(verdict, 0);
+
+    VerdictResultStream result = exec.streamsql(sql);
+
+    while (result.hasNext()) {
+      result.next();
+    }
+
+    int tempCount = 0;
+    conn.setCatalog(MYSQL_DATABASE);
+    ResultSet tables = conn.createStatement().executeQuery("show tables");
+    while (tables.next()) {
+      String tableName = tables.getString(1);
+      if (tableName.startsWith("verdictdbtemptable")) {
+        ++tempCount;
+      }
+    }
+    assertTrue(0 < tempCount);
+    exec.terminate();
+  }
+
+  @Test
+  public void testTempTableClearAfterTerminate()
+      throws VerdictDBException, SQLException, IOException {
+    String filename = "query1.sql";
+    File file = new File("src/test/resources/tpch_test_query/" + filename);
+    String sql = Files.toString(file, Charsets.UTF_8);
+    DbmsConnection dbmsConn = JdbcConnection.create(conn);
+    ((JdbcConnection) dbmsConn).setOutputDebugMessage(true);
+    dbmsConn.setDefaultSchema(MYSQL_DATABASE);
+    VerdictContext verdict = new VerdictContext(dbmsConn);
+    ExecutionContext exec = new ExecutionContext(verdict, 0);
+
+    VerdictResultStream result = exec.streamsql(sql);
+
+    while (result.hasNext()) {
+      result.next();
+    }
+
+    exec.terminate();
+
+    int tempCount = 0;
+    conn.setCatalog(MYSQL_DATABASE);
+    ResultSet tables = conn.createStatement().executeQuery("show tables");
+    while (tables.next()) {
+      String tableName = tables.getString(1);
+      if (tableName.startsWith("verdictdbtemptable")) {
+        System.out.println(tableName);
+        ++tempCount;
+      }
+    }
+    assertEquals(0, tempCount);
+  }
 }


### PR DESCRIPTION
Resolves #198 