### PR TITLE
Use randomized schema names for metadata and temp tables.

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -141,8 +141,17 @@ public class VerdictContext {
     VerdictOption options = new VerdictOption();
     options.parseConnectionString(jdbcConnectionString);
     return new VerdictContext(ConcurrentJdbcConnection.create(jdbcConnectionString, info), options);
-    //    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, user, password);
-    //    return fromJdbcConnection(jdbcConn);
+  }
+
+  public static VerdictContext fromConnectionString(
+      String jdbcConnectionString, String user, String password, VerdictOption options)
+      throws SQLException, VerdictDBDbmsException {
+    attemptLoadDriverClass(jdbcConnectionString);
+    Properties info = new Properties();
+    info.setProperty("user", user);
+    info.setProperty("password", password);
+    options.parseConnectionString(jdbcConnectionString);
+    return new VerdictContext(ConcurrentJdbcConnection.create(jdbcConnectionString, info), options);
   }
 
   private static void attemptLoadDriverClass(String jdbcConnectionString) {

--- a/src/main/java/org/verdictdb/jdbc41/VerdictConnection.java
+++ b/src/main/java/org/verdictdb/jdbc41/VerdictConnection.java
@@ -16,28 +16,17 @@
 
 package org.verdictdb.jdbc41;
 
-import java.sql.Array;
-import java.sql.Blob;
-import java.sql.CallableStatement;
-import java.sql.Clob;
-import java.sql.DatabaseMetaData;
-import java.sql.NClob;
-import java.sql.SQLClientInfoException;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLWarning;
-import java.sql.SQLXML;
-import java.sql.Savepoint;
-import java.sql.Struct;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executor;
-
 import org.verdictdb.VerdictContext;
+import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.CachedDbmsConnection;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
 
 public class VerdictConnection implements java.sql.Connection {
 
@@ -59,6 +48,12 @@ public class VerdictConnection implements java.sql.Connection {
   public VerdictConnection(String url, String user, String password)
       throws VerdictDBDbmsException, SQLException {
     vc = VerdictContext.fromConnectionString(url, user, password);
+    isOpen = true;
+  }
+
+  public VerdictConnection(String url, String user, String password, VerdictOption options)
+      throws VerdictDBDbmsException, SQLException {
+    vc = VerdictContext.fromConnectionString(url, user, password, options);
     isOpen = true;
   }
 
@@ -133,8 +128,8 @@ public class VerdictConnection implements java.sql.Connection {
   @Override
   public void close() throws SQLException {
     vc.close();
-//    JdbcConnection conn = vc.getJdbcConnection();
-//    if (conn != null) conn.getConnection().close();
+    //    JdbcConnection conn = vc.getJdbcConnection();
+    //    if (conn != null) conn.getConnection().close();
     isOpen = false;
   }
 
@@ -306,8 +301,8 @@ public class VerdictConnection implements java.sql.Connection {
   @Override
   public boolean isValid(int timeout) throws SQLException {
     return !vc.isClosed();
-//    JdbcConnection conn = vc.getJdbcConnection();
-//    return (conn != null) && conn.getConnection().isValid(timeout);
+    //    JdbcConnection conn = vc.getJdbcConnection();
+    //    return (conn != null) && conn.getConnection().isValid(timeout);
   }
 
   @Override

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -60,6 +60,7 @@ public class CreateScrambleTableFromSqlTest {
 
   @BeforeClass
   public static void setup() throws VerdictDBDbmsException, SQLException, IOException {
+    options.setVerdictTempSchemaName(TEMP_SCHEMA_NAME);
     setupMysql();
     setupImpala();
     setupRedshift();

--- a/src/test/java/org/verdictdb/coordinator/ImpalaTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ImpalaTpchSelectQueryCoordinatorTest.java
@@ -1,14 +1,7 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -27,8 +20,14 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.ImpalaSyntax;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImpalaTpchSelectQueryCoordinatorTest {
 
@@ -44,7 +43,7 @@ public class ImpalaTpchSelectQueryCoordinatorTest {
 
   // to avoid possible conflicts among concurrent tests
   private static final String IMPALA_DATABASE =
-      "scrambling_coordinator_test_" + RandomStringUtils.randomNumeric(3);
+      "scrambling_coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String IMPALA_UESR = "";
 

--- a/src/test/java/org/verdictdb/coordinator/ImpalaUniformScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ImpalaUniformScramblingCoordinatorTest.java
@@ -1,13 +1,5 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -20,6 +12,14 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
 public class ImpalaUniformScramblingCoordinatorTest {
 
   private static Connection impalaConn;
@@ -30,7 +30,7 @@ public class ImpalaUniformScramblingCoordinatorTest {
 
   // to avoid possible conflicts among concurrent tests
   private static final String IMPALA_DATABASE =
-      "scrambling_coordinator_test_" + RandomStringUtils.randomAlphanumeric(4);
+      "scrambling_coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String IMPALA_USER = "";
 

--- a/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
@@ -53,7 +53,7 @@ public class MetaDataStatementsTest {
   }
 
   private static final String MYSQL_DATABASE =
-      "data_type_test" + RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+      "data_type_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String MYSQL_USER = "root";
 
@@ -66,7 +66,7 @@ public class MetaDataStatementsTest {
   }
 
   private static final String IMPALA_DATABASE =
-      "data_type_test" + RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+      "data_type_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String IMPALA_USER = "";
 
@@ -104,10 +104,10 @@ public class MetaDataStatementsTest {
   }
 
   private static final String PostgresRedshift_SCHEMA_NAME =
-      "data_type_test" + RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+      "data_type_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String TABLE_NAME =
-      "data_type_test" + RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+      "data_type_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   @BeforeClass
   public static void setup() throws SQLException, VerdictDBDbmsException, IOException {

--- a/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
@@ -2,6 +2,7 @@ package org.verdictdb.coordinator;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -59,7 +60,8 @@ public class MySqlTpchSelectQueryCoordinatorTest {
     }
   }
 
-  private static final String MYSQL_DATABASE = "coordinator_test";
+  private static final String MYSQL_DATABASE =
+      "coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String MYSQL_UESR = "root";
 

--- a/src/test/java/org/verdictdb/coordinator/PostgreSqlTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/PostgreSqlTpchSelectQueryCoordinatorTest.java
@@ -2,6 +2,7 @@ package org.verdictdb.coordinator;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -40,7 +41,8 @@ public class PostgreSqlTpchSelectQueryCoordinatorTest {
 
   private static final String POSTGRES_DATABASE = "test";
 
-  private static final String POSTGRES_SCHEMA = "scrambling_coordinator_test";
+  private static final String POSTGRES_SCHEMA =
+      "scrambling_coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String POSTGRES_USER = "postgres";
 

--- a/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
@@ -2,6 +2,7 @@ package org.verdictdb.coordinator;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -52,7 +53,8 @@ public class RedshiftTpchSelectQueryCoordinatorTest {
 
   private static final String REDSHIFT_DATABASE = "dev";
 
-  private static final String REDSHIFT_SCHEMA = "tpch";
+  private static final String REDSHIFT_SCHEMA =
+      "tpch_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String REDSHIFT_USER;
 

--- a/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
@@ -1,14 +1,5 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -20,6 +11,15 @@ import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class RedshiftUniformScramblingCoordinatorTest {
 
@@ -34,7 +34,7 @@ public class RedshiftUniformScramblingCoordinatorTest {
   private static final String REDSHIFT_DATABASE = "dev";
 
   private static final String REDSHIFT_SCHEMA =
-      "uniform_scrambling_test_" + RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+      "uniform_scrambling_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   private static final String REDSHIFT_USER;
 

--- a/src/test/java/org/verdictdb/coordinator/SparkTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/SparkTpchSelectQueryCoordinatorTest.java
@@ -1,5 +1,6 @@
 package org.verdictdb.coordinator;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -37,7 +38,8 @@ public class SparkTpchSelectQueryCoordinatorTest {
 
   static ScrambleMetaSet meta = new ScrambleMetaSet();
 
-  static final String TEST_SCHEMA = "scrambling_coordinator_test";
+  static final String TEST_SCHEMA =
+      "scrambling_coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   static DbmsConnection conn;
 


### PR DESCRIPTION
This seems to mitigate the issue of interference between concurrent unit tests (#204)
