### PR TITLE
prints query completion log for debugging.

### DIFF
--- a/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
@@ -111,6 +111,7 @@ public class MySqlTpchSelectQueryCoordinatorTest {
     ExecutionResultReader reader = coordinator.process(sql);
 
     ResultSet rs = stmt.executeQuery(sql);
+    System.out.println(String.format("Query %d Executed.", queryNum));
     return new ImmutablePair<>(reader, rs);
   }
 


### PR DESCRIPTION
Added for MySqlTpchSelectQueryCoordinatorTest, which seems to have occasional errors caused by "Too long with no output (exceeded 10m0s)" for some reason