### PR TITLE
 Allow 'bypass' keyword in a SQL, which runs the query directly at the backend database

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -25,6 +25,7 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.coordinator.ExecutionContext;
 import org.verdictdb.coordinator.VerdictResultStream;
 import org.verdictdb.coordinator.VerdictSingleResult;
+import org.verdictdb.coordinator.VerdictSingleResultFromDbmsQueryResult;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
@@ -235,6 +236,19 @@ public class VerdictContext {
       String originalSchema, String originalTable, String newSchema, String newTable) {}
 
   /**
+   * Check whether given sql contains 'bypass' keyword at the beginning
+   *
+   * @param sql original sql
+   * @return without 'bypass' keyword if the original sql begins with it. null otherwise.
+   */
+  private String checkBypass(String sql) {
+    if (sql.trim().toLowerCase().startsWith("bypass")) {
+      return sql.trim().substring(6);
+    }
+    return null;
+  }
+
+  /**
    * Returns a reliable result set as an answer. Right now, simply returns the first batch of
    * Continuous results.
    *
@@ -246,10 +260,15 @@ public class VerdictContext {
    * @throws VerdictDBException
    */
   public VerdictSingleResult sql(String query) throws VerdictDBException {
-    ExecutionContext exec = createNewExecutionContext();
-    VerdictSingleResult result = exec.sql(query);
-    removeExecutionContext(exec);
-    return result;
+    String bypassSql = checkBypass(query);
+    if (bypassSql != null) {
+      return executeAsIs(bypassSql);
+    } else {
+      ExecutionContext exec = createNewExecutionContext();
+      VerdictSingleResult result = exec.sql(query);
+      removeExecutionContext(exec);
+      return result;
+    }
   }
 
   /**
@@ -262,5 +281,9 @@ public class VerdictContext {
     ExecutionContext exec = createNewExecutionContext();
     VerdictResultStream stream = exec.streamsql(query);
     return stream;
+  }
+
+  private VerdictSingleResult executeAsIs(String sql) throws VerdictDBDbmsException {
+    return new VerdictSingleResultFromDbmsQueryResult(conn.execute(sql));
   }
 }

--- a/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
+++ b/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
@@ -16,13 +16,12 @@
 
 package org.verdictdb.commons;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
 
 public class VerdictDBLogger implements org.slf4j.Logger {
 

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -18,7 +18,6 @@ package org.verdictdb.coordinator;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.verdictdb.VerdictContext;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.DbmsConnection;
@@ -51,7 +50,7 @@ import static org.verdictdb.coordinator.VerdictSingleResultFromListData.createWi
  */
 public class ExecutionContext {
 
-  private VerdictContext context;
+  private DbmsConnection conn;
 
   private QueryContext queryContext;
 
@@ -72,14 +71,16 @@ public class ExecutionContext {
   }
 
   /**
-   * @param context Parent context
-   * @param serialNumber
+   * @param conn DbmsConnection
+   * @param contextId parent's context id
+   * @param serialNumber serial number of this ExecutionContext
    * @param options
    */
-  public ExecutionContext(VerdictContext context, long serialNumber, VerdictOption options) {
-    this.context = context;
+  public ExecutionContext(
+      DbmsConnection conn, String contextId, long serialNumber, VerdictOption options) {
+    this.conn = conn;
     this.serialNumber = serialNumber;
-    this.queryContext = new QueryContext(context.getContextId(), serialNumber);
+    this.queryContext = new QueryContext(contextId, serialNumber);
     this.options = options;
   }
 
@@ -87,15 +88,37 @@ public class ExecutionContext {
     return serialNumber;
   }
 
-  public VerdictSingleResult sql(String query) throws VerdictDBException {
-    VerdictResultStream stream = streamsql(query);
-    if (stream == null) {
-      return null;
+  /**
+   * Check whether given sql contains 'bypass' keyword at the beginning
+   *
+   * @param sql original sql
+   * @return without 'bypass' keyword if the original sql begins with it. null otherwise.
+   */
+  private String checkBypass(String sql) {
+    if (sql.trim().toLowerCase().startsWith("bypass")) {
+      return sql.trim().substring(6);
     }
+    return null;
+  }
 
-    VerdictSingleResult result = stream.next();
-    stream.close();
-    return result;
+  private VerdictSingleResult executeAsIs(String sql) throws VerdictDBDbmsException {
+    return new VerdictSingleResultFromDbmsQueryResult(conn.execute(sql));
+  }
+
+  public VerdictSingleResult sql(String query) throws VerdictDBException {
+    String bypassSql = checkBypass(query);
+    if (bypassSql != null) {
+      return executeAsIs(bypassSql);
+    } else {
+      VerdictResultStream stream = streamsql(query);
+      if (stream == null) {
+        return null;
+      }
+
+      VerdictSingleResult result = stream.next();
+      stream.close();
+      return result;
+    }
   }
 
   public VerdictResultStream streamsql(String query) throws VerdictDBException {
@@ -105,8 +128,7 @@ public class ExecutionContext {
 
     if (queryType.equals(QueryType.select)) {
       LOG.debug("Query type: select");
-      SelectQueryCoordinator coordinator =
-          new SelectQueryCoordinator(context.getCopiedConnection(), options);
+      SelectQueryCoordinator coordinator = new SelectQueryCoordinator(conn, options);
       ExecutionResultReader reader = coordinator.process(query, queryContext);
       VerdictResultStream stream = new VerdictResultStreamFromExecutionResultReader(reader, this);
       return stream;
@@ -115,9 +137,7 @@ public class ExecutionContext {
       CreateScrambleQuery scrambleQuery = generateScrambleQuery(query);
       ScramblingCoordinator scrambler =
           new ScramblingCoordinator(
-              context.getCopiedConnection(),
-              scrambleQuery.getNewSchema(),
-              options.getVerdictTempSchemaName());
+              conn, scrambleQuery.getNewSchema(), options.getVerdictTempSchemaName());
 
       // Specifying size/ratio of scrambled table is not supported.
       if (scrambleQuery.getSize() != 1.0) {
@@ -134,7 +154,7 @@ public class ExecutionContext {
       //              scrambleQuery.getMethod()); // dyoon: size is not used atm?
 
       // Add metadata to metastore
-      ScrambleMetaStore metaStore = new ScrambleMetaStore(context.getConnection(), options);
+      ScrambleMetaStore metaStore = new ScrambleMetaStore(conn, options);
       metaStore.addToStore(meta);
       return null;
     } else if (queryType.equals(QueryType.set_default_schema)) {
@@ -197,7 +217,7 @@ public class ExecutionContext {
 
   private VerdictResultStream generateShowSchemaResultFromQuery() throws VerdictDBException {
     List<String> header = Arrays.asList("schema");
-    List<String> rows = context.getConnection().getSchemas();
+    List<String> rows = conn.getSchemas();
     VerdictSingleResultFromListData result = createWithSingleColumn(header, (List) rows);
     return new VerdictResultStreamFromSingleResult(result);
   }
@@ -207,7 +227,7 @@ public class ExecutionContext {
     VerdictSQLParser parser = NonValidatingSQLParser.parserOf(query);
     String schema = parser.show_tables_statement().schema.getText();
     List<String> header = Arrays.asList("table");
-    List<String> rows = context.getConnection().getTables(schema);
+    List<String> rows = conn.getTables(schema);
     VerdictSingleResultFromListData result = createWithSingleColumn(header, (List) rows);
     return new VerdictResultStreamFromSingleResult(result);
   }
@@ -223,7 +243,7 @@ public class ExecutionContext {
             String table = ctx.table.table.getText();
             String schema = ctx.table.schema.getText();
             if (schema == null) {
-              schema = context.getConnection().getDefaultSchema();
+              schema = conn.getDefaultSchema();
             }
             return new ImmutablePair<>(schema, table);
           }
@@ -232,9 +252,9 @@ public class ExecutionContext {
     String table = t.getRight();
     String schema = t.getLeft();
     if (schema == null) {
-      schema = context.getConnection().getDefaultSchema();
+      schema = conn.getDefaultSchema();
     }
-    List<Pair<String, String>> columnInfo = context.getConnection().getColumns(schema, table);
+    List<Pair<String, String>> columnInfo = conn.getColumns(schema, table);
     List<List<String>> newColumnInfo = new ArrayList<>();
     for (Pair<String, String> pair : columnInfo) {
       newColumnInfo.add(Arrays.asList(pair.getLeft(), pair.getRight()));
@@ -248,7 +268,7 @@ public class ExecutionContext {
   private void updateDefaultSchemaFromQuery(String query) {
     VerdictSQLParser parser = NonValidatingSQLParser.parserOf(query);
     String schema = parser.use_statement().database.getText();
-    context.getConnection().setDefaultSchema(schema);
+    conn.setDefaultSchema(schema);
   }
 
   /**
@@ -258,12 +278,13 @@ public class ExecutionContext {
    */
   public void terminate() {
     try {
-      DbmsConnection conn = context.getCopiedConnection();
       String schema = options.getVerdictTempSchemaName();
       String tempTablePrefix =
           String.format(
               "%s_%s_%d",
-              VerdictOption.getVerdictTempTablePrefix(), context.getContextId(), this.serialNumber);
+              VerdictOption.getVerdictTempTablePrefix(),
+              queryContext.getVerdictContextId(),
+              this.serialNumber);
       List<String> tempTableList = new ArrayList<>();
 
       DbmsQueryResult rs;

--- a/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
+++ b/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
@@ -21,31 +21,25 @@ import org.verdictdb.coordinator.ExecutionContext;
 import org.verdictdb.coordinator.VerdictSingleResult;
 import org.verdictdb.exception.VerdictDBException;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLWarning;
+import java.sql.*;
 
 public class VerdictStatement implements java.sql.Statement {
 
-  VerdictConnection jdbcConn;
-
-  VerdictContext context;
+  Connection conn;
 
   ExecutionContext executionContext;
 
   VerdictSingleResult result;
 
-  public VerdictStatement(VerdictConnection jdbcConn, VerdictContext context) {
-    this.jdbcConn = jdbcConn;
-    this.context = context;
+  public VerdictStatement(Connection conn, VerdictContext context) {
+    this.conn = conn;
     this.executionContext = context.createNewExecutionContext();
   }
 
   @Override
   public boolean execute(String sql) throws SQLException {
     try {
-      result = context.sql(sql);
+      result = executionContext.sql(sql);
       if (result == null) {
         return false;
       }
@@ -58,7 +52,7 @@ public class VerdictStatement implements java.sql.Statement {
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     try {
-      result = context.sql(sql);
+      result = executionContext.sql(sql);
       return new VerdictResultSet(result);
     } catch (VerdictDBException e) {
       throw new SQLException(e);
@@ -68,7 +62,7 @@ public class VerdictStatement implements java.sql.Statement {
   @Override
   public int executeUpdate(String sql) throws SQLException {
     try {
-      result = context.sql(sql);
+      result = executionContext.sql(sql);
       return (int) result.getRowCount();
     } catch (VerdictDBException e) {
       throw new SQLException(e);
@@ -94,7 +88,7 @@ public class VerdictStatement implements java.sql.Statement {
 
   @Override
   public java.sql.Connection getConnection() throws SQLException {
-    return jdbcConn;
+    return conn;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
+++ b/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
@@ -16,15 +16,15 @@
 
 package org.verdictdb.jdbc41;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLWarning;
-
 import org.verdictdb.VerdictContext;
+import org.verdictdb.connection.*;
 import org.verdictdb.coordinator.ExecutionContext;
 import org.verdictdb.coordinator.VerdictSingleResult;
+import org.verdictdb.coordinator.VerdictSingleResultFromDbmsQueryResult;
+import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
+
+import java.sql.*;
 
 public class VerdictStatement implements java.sql.Statement {
 
@@ -42,10 +42,67 @@ public class VerdictStatement implements java.sql.Statement {
     this.executionContext = context.createNewExecutionContext();
   }
 
+  /**
+   * Check whether given sql contains 'bypass' keyword at the beginning
+   *
+   * @param sql original sql
+   * @return without 'bypass' keyword if the original sql begins with it. null otherwise.
+   */
+  private String checkBypass(String sql) {
+    if (sql.trim().toLowerCase().startsWith("bypass")) {
+      return sql.trim().substring(6);
+    }
+    return null;
+  }
+
+  private VerdictSingleResult executeAsIs(String sql) throws SQLException, VerdictDBDbmsException {
+    DbmsConnection dbmsConn = context.getConnection();
+    if (dbmsConn instanceof CachedDbmsConnection) {
+      dbmsConn = ((CachedDbmsConnection) dbmsConn).getOriginalConnection();
+    }
+    if (dbmsConn instanceof ConcurrentJdbcConnection) {
+      dbmsConn = ((ConcurrentJdbcConnection) dbmsConn).getNextConnection();
+    }
+    if (dbmsConn instanceof JdbcConnection) {
+      Statement stmt = ((JdbcConnection) dbmsConn).getConnection().createStatement();
+      boolean exist = stmt.execute(sql);
+      if (exist)
+        return new VerdictSingleResultFromDbmsQueryResult(new JdbcQueryResult(stmt.getResultSet()));
+      else return null;
+    } else if (dbmsConn instanceof SparkConnection) {
+      return new VerdictSingleResultFromDbmsQueryResult(dbmsConn.execute(sql));
+    } else {
+      throw new VerdictDBDbmsException("Unsupported DBMS for BYPASS statement.");
+    }
+  }
+
+  private int executeUpdateAsIs(String sql) throws SQLException, VerdictDBDbmsException {
+    DbmsConnection dbmsConn = context.getConnection();
+    if (dbmsConn instanceof CachedDbmsConnection) {
+      dbmsConn = ((CachedDbmsConnection) dbmsConn).getOriginalConnection();
+    }
+    if (dbmsConn instanceof ConcurrentJdbcConnection) {
+      dbmsConn = ((ConcurrentJdbcConnection) dbmsConn).getNextConnection();
+    }
+    if (dbmsConn instanceof JdbcConnection) {
+      return ((JdbcConnection) dbmsConn).getConnection().createStatement().executeUpdate(sql);
+    } else if (dbmsConn instanceof SparkConnection) {
+      return (int) dbmsConn.execute(sql).getRowCount();
+    } else {
+      throw new VerdictDBDbmsException("Unsupported DBMS for BYPASS statement.");
+    }
+  }
+
   @Override
   public boolean execute(String sql) throws SQLException {
     try {
-      result = executionContext.sql(sql);
+      String bypassSql = checkBypass(sql);
+      if (bypassSql != null) {
+        result = this.executeAsIs(bypassSql);
+      } else {
+        result = executionContext.sql(sql);
+      }
+
       if (result == null) {
         return false;
       }
@@ -58,7 +115,12 @@ public class VerdictStatement implements java.sql.Statement {
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     try {
-      result = executionContext.sql(sql);
+      String bypassSql = checkBypass(sql);
+      if (bypassSql != null) {
+        result = this.executeAsIs(bypassSql);
+      } else {
+        result = executionContext.sql(sql);
+      }
       return new VerdictResultSet(result);
     } catch (VerdictDBException e) {
       throw new SQLException(e);
@@ -68,7 +130,13 @@ public class VerdictStatement implements java.sql.Statement {
   @Override
   public int executeUpdate(String sql) throws SQLException {
     try {
-      result = executionContext.sql(sql);
+      String bypassSql = checkBypass(sql);
+      if (bypassSql != null) {
+        result = null; // This should be null for update.
+        return this.executeUpdateAsIs(bypassSql);
+      } else {
+        result = executionContext.sql(sql);
+      }
       return (int) result.getRowCount();
     } catch (VerdictDBException e) {
       throw new SQLException(e);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
+            <level>INFO</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>

--- a/src/test/java/org/verdictdb/commons/DatabaseConnectionHelpers.java
+++ b/src/test/java/org/verdictdb/commons/DatabaseConnectionHelpers.java
@@ -1,15 +1,8 @@
 package org.verdictdb.commons;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.spark.sql.SparkSession;
 import org.postgresql.copy.CopyManager;
@@ -22,9 +15,15 @@ import org.verdictdb.sqlsyntax.ImpalaSyntax;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
 import org.verdictdb.sqlsyntax.RedshiftSyntax;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
-import com.google.common.io.Files;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DatabaseConnectionHelpers {
 

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -11,6 +11,7 @@ import org.junit.runners.Parameterized;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.JdbcConnection;
+import org.verdictdb.core.resulthandler.ExecutionResultReader;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.sqlobject.AbstractRelation;
@@ -159,8 +160,10 @@ public class CreateScrambleTableFromSqlTest {
             DatabaseConnectionHelpers.REDSHIFT_HOST, DatabaseConnectionHelpers.REDSHIFT_DATABASE);
     String vcConnectionString =
         String.format(
-            "jdbc:verdict:redshift://%s/%s",
-            DatabaseConnectionHelpers.REDSHIFT_HOST, DatabaseConnectionHelpers.REDSHIFT_DATABASE);
+            "jdbc:verdict:redshift://%s/%s;verdictdbtempschema=%s",
+            DatabaseConnectionHelpers.REDSHIFT_HOST,
+            DatabaseConnectionHelpers.REDSHIFT_DATABASE,
+            TEMP_SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupRedshift(
             connectionString,
@@ -308,8 +311,11 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn);
-    coordinator.process(countOriginalSql);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
+    ExecutionResultReader reader = coordinator.process(countOriginalSql);
+    while (reader.hasNext()) {
+      reader.next();
+    }
     SelectQuery query = coordinator.getLastQuery();
 
     AbstractRelation table = query.getFromList().get(0);
@@ -344,8 +350,11 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn);
-    coordinator.process(countOriginalSql);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
+    ExecutionResultReader reader = coordinator.process(countOriginalSql);
+    while (reader.hasNext()) {
+      reader.next();
+    }
     SelectQuery query = coordinator.getLastQuery();
 
     AbstractRelation table = query.getFromList().get(0);

--- a/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
@@ -98,7 +98,7 @@ public class ExecutionContextTest {
     String sql = String.format("select avg(l_quantity) from %s.lineitem_scrambled", MYSQL_DATABASE);
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
     VerdictContext verdict = new VerdictContext(dbmsConn);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options.copy());
+    ExecutionContext exec = new ExecutionContext(dbmsConn, verdict.getContextId(), 0, options);
 
     VerdictSingleResult result = exec.sql(sql);
   }
@@ -113,7 +113,7 @@ public class ExecutionContextTest {
     ((JdbcConnection) dbmsConn).setOutputDebugMessage(true);
     dbmsConn.setDefaultSchema(MYSQL_DATABASE);
     VerdictContext verdict = new VerdictContext(dbmsConn, options);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options);
+    ExecutionContext exec = new ExecutionContext(dbmsConn, verdict.getContextId(), 0, options);
 
     VerdictResultStream result = exec.streamsql(sql);
 
@@ -143,7 +143,7 @@ public class ExecutionContextTest {
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
     dbmsConn.setDefaultSchema(MYSQL_DATABASE);
     VerdictContext verdict = new VerdictContext(dbmsConn, options);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options);
+    ExecutionContext exec = new ExecutionContext(dbmsConn, verdict.getContextId(), 0, options);
 
     VerdictResultStream result = exec.streamsql(sql);
 

--- a/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
@@ -261,7 +261,7 @@ public class MetaDataStatementsTest {
         new CachedDbmsConnection(
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options);
+    ExecutionContext exec = new ExecutionContext(dbmsconn, verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql("show schemas");
 
     Set<String> expected = new HashSet<>();
@@ -307,7 +307,7 @@ public class MetaDataStatementsTest {
         new CachedDbmsConnection(
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options);
+    ExecutionContext exec = new ExecutionContext(dbmsconn, verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
 
     Set<String> expected = new HashSet<>();
@@ -357,7 +357,7 @@ public class MetaDataStatementsTest {
         new CachedDbmsConnection(
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
-    ExecutionContext exec = new ExecutionContext(verdict, 0, options);
+    ExecutionContext exec = new ExecutionContext(dbmsconn, verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
     while (jdbcRs.next()) {
       result.next();

--- a/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
@@ -60,6 +60,8 @@ public class RedshiftTpchSelectQueryCoordinatorTest {
 
   private static final String REDSHIFT_PASSWORD;
 
+  private static VerdictOption options = new VerdictOption();
+
   static {
     REDSHIFT_HOST = System.getenv("VERDICTDB_TEST_REDSHIFT_ENDPOINT");
     REDSHIFT_USER = System.getenv("VERDICTDB_TEST_REDSHIFT_USER");
@@ -71,19 +73,12 @@ public class RedshiftTpchSelectQueryCoordinatorTest {
 
   Pair<ExecutionResultReader, ResultSet> getAnswerPair(int queryNum)
       throws VerdictDBException, SQLException, IOException {
-    stmt.execute(
-        String.format(
-            "drop schema if exists \"%s\" cascade", VerdictOption.getDefaultTempSchemaName()));
-    stmt.execute(
-        String.format(
-            "create schema if not exists \"%s\"", VerdictOption.getDefaultTempSchemaName()));
-
     String filename = "query" + queryNum + ".sql";
     File file = new File("src/test/resources/tpch_test_query/" + filename);
     String sql = Files.toString(file, Charsets.UTF_8);
 
     dbmsConn.setDefaultSchema(REDSHIFT_SCHEMA);
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(dbmsConn);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(dbmsConn, options);
     coordinator.setScrambleMetaSet(meta);
     ExecutionResultReader reader = coordinator.process(sql);
 
@@ -101,6 +96,8 @@ public class RedshiftTpchSelectQueryCoordinatorTest {
     stmt = redshiftConn.createStatement();
     stmt.execute(String.format("set search_path to \"%s\"", REDSHIFT_SCHEMA));
     dbmsConn = new CachedDbmsConnection(new JdbcConnection(redshiftConn, new RedshiftSyntax()));
+
+    options.setVerdictTempSchemaName(REDSHIFT_SCHEMA);
     // Create Scramble table
     stmt.execute(
         String.format("DROP TABLE IF EXISTS \"%s\".\"lineitem_scrambled\"", REDSHIFT_SCHEMA));

--- a/src/test/java/org/verdictdb/jdbc41/DriverTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/DriverTest.java
@@ -7,6 +7,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
+import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.exception.VerdictDBDbmsException;
 
 import java.io.File;
@@ -31,6 +32,8 @@ public class DriverTest {
 
   private static Connection conn;
 
+  private static VerdictOption options = new VerdictOption();
+
   static {
     REDSHIFT_HOST = System.getenv("VERDICTDB_TEST_REDSHIFT_ENDPOINT");
     REDSHIFT_USER = System.getenv("VERDICTDB_TEST_REDSHIFT_USER");
@@ -39,6 +42,7 @@ public class DriverTest {
 
   @BeforeClass
   public static void setup() throws VerdictDBDbmsException, SQLException, IOException {
+    options.setVerdictTempSchemaName(REDSHIFT_SCHEMA);
     String connectionString =
         String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
     conn =
@@ -59,6 +63,7 @@ public class DriverTest {
     Properties info = new Properties();
     info.setProperty("user", REDSHIFT_USER);
     info.setProperty("password", REDSHIFT_PASSWORD);
+    info.setProperty("verdictdbtempschema", REDSHIFT_SCHEMA);
     Connection conn = DriverManager.getConnection(verdictConnectionString, info);
 
     ResultSet rs =

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -350,11 +350,9 @@ public class JdbcCommonQueryForAllDatabasesTest {
                 "BYPASS INSERT INTO %s.people(id, name, gender, age, height, nation, birth) "
                     + "VALUES(10, 'mike', 'male', 38, 190, 'Russia', '1980-10-10 10:10:10')",
                 SCHEMA_NAME));
-    if (database.equals("impala")) {
-      assertEquals(-1, count); // Impala JDBC always returns -1.
-    } else {
-      assertEquals(1, count);
-    }
+    // We do not differentiate between execute and executeUpdate. As a result we always return 0 for
+    // executeUpdate
+    assertEquals(0, count);
   }
 
   @Test

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -151,6 +151,10 @@ public class JdbcCommonQueryForAllDatabasesTest {
         String.format(
             "CREATE TABLE %s.people(id smallint, name varchar(255), gender varchar(8), age float, height float, nation varchar(8), birth timestamp)",
             SCHEMA_NAME));
+    stmt.execute(
+        String.format(
+            "CREATE TABLE %s.drop_table(id smallint, name varchar(255), gender varchar(8), age float, height float, nation varchar(8), birth timestamp)",
+            SCHEMA_NAME));
     for (List<Object> row : contents) {
       String id = row.get(0).toString();
       String name = row.get(1).toString();
@@ -186,6 +190,10 @@ public class JdbcCommonQueryForAllDatabasesTest {
     stmt.execute(
         String.format(
             "CREATE TABLE %s.people(id smallint, name string, gender string, age float, height float, nation string, birth timestamp)",
+            SCHEMA_NAME));
+    stmt.execute(
+        String.format(
+            "CREATE TABLE %s.drop_table(id smallint, name varchar(255), gender varchar(8), age float, height float, nation varchar(8), birth timestamp)",
             SCHEMA_NAME));
     for (List<Object> row : contents) {
       String id = row.get(0).toString();
@@ -299,6 +307,53 @@ public class JdbcCommonQueryForAllDatabasesTest {
       assertEquals(jdbcRs.getFloat(5), vcRs.getFloat(5), 0.000001);
       assertEquals(jdbcRs.getString(6), vcRs.getString(6));
       assertEquals(jdbcRs.getTimestamp(7), vcRs.getTimestamp(7));
+    }
+  }
+
+  @Test
+  public void runSelectQueryWithBypassTest() throws SQLException {
+    String sql = String.format("SELECT * FROM %s", SCHEMA_NAME) + ".people order by birth";
+    String bypassSql =
+        String.format("BYPASS SELECT * FROM %s", SCHEMA_NAME) + ".people order by birth";
+    Statement jdbcStmt = connMap.get(database).createStatement();
+    Statement vcStmt = vcMap.get(database).createStatement();
+
+    ResultSet jdbcRs = jdbcStmt.executeQuery(sql);
+    ResultSet vcRs = vcStmt.executeQuery(bypassSql);
+    assertEquals(jdbcRs.getMetaData().getColumnCount(), vcRs.getMetaData().getColumnCount());
+    assertEquals(jdbcRs.getMetaData().getColumnCount(), 7);
+    while (jdbcRs.next() && vcRs.next()) {
+      assertEquals(jdbcRs.getInt(1), vcRs.getInt(1));
+      assertEquals(jdbcRs.getString(2), vcRs.getString(2));
+      assertEquals(jdbcRs.getString(3), vcRs.getString(3));
+      assertEquals(jdbcRs.getFloat(4), vcRs.getFloat(4), 0.000001);
+      assertEquals(jdbcRs.getFloat(5), vcRs.getFloat(5), 0.000001);
+      assertEquals(jdbcRs.getString(6), vcRs.getString(6));
+      assertEquals(jdbcRs.getTimestamp(7), vcRs.getTimestamp(7));
+    }
+  }
+
+  @Test
+  public void runDropQueryWithBypassTest() throws SQLException {
+    String bypassSql = String.format("BYPASS DROP TABLE IF EXISTS %s.drop_table", SCHEMA_NAME);
+    Statement vcStmt = vcMap.get(database).createStatement();
+    vcStmt.execute(bypassSql);
+    vcStmt.close();
+  }
+
+  @Test
+  public void runInsertQueryWithBypassTest() throws SQLException {
+    Statement stmt = vcMap.get(database).createStatement();
+    int count =
+        stmt.executeUpdate(
+            String.format(
+                "BYPASS INSERT INTO %s.people(id, name, gender, age, height, nation, birth) "
+                    + "VALUES(10, 'mike', 'male', 38, 190, 'Russia', '1980-10-10 10:10:10')",
+                SCHEMA_NAME));
+    if (database.equals("impala")) {
+      assertEquals(-1, count); // Impala JDBC always returns -1.
+    } else {
+      assertEquals(1, count);
     }
   }
 

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -242,7 +242,9 @@ public class JdbcCommonQueryForAllDatabasesTest {
 
   public static Connection setupRedshift() throws SQLException, VerdictDBDbmsException {
     String connectionString =
-        String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
+        String.format(
+            "jdbc:redshift://%s/%s;verdictdbtempschema=%s",
+            REDSHIFT_HOST, REDSHIFT_DATABASE, SCHEMA_NAME);
     Connection conn =
         DriverManager.getConnection(connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD);
     VerdictConnection vc =

--- a/src/test/java/org/verdictdb/jdbc41/JdbcMetaDataForRedshiftTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcMetaDataForRedshiftTest.java
@@ -1,10 +1,5 @@
 package org.verdictdb.jdbc41;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -12,6 +7,11 @@ import org.junit.Test;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class JdbcMetaDataForRedshiftTest {
 

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -48,7 +48,7 @@ public class JdbcTpchQueryForAllDatabasesTest {
   // TODO: Add support for all four databases
   //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
   private static final String[] targetDatabases = {"mysql", "impala", "redshift"};
-  //  private static final String[] targetDatabases = { "impala" };
+  //  private static final String[] targetDatabases = {"redshift"};
 
   public JdbcTpchQueryForAllDatabasesTest(String database, String query) {
     this.database = database;
@@ -87,8 +87,6 @@ public class JdbcTpchQueryForAllDatabasesTest {
 
   private static final String REDSHIFT_DATABASE = "dev";
 
-  private static final String REDSHIFT_SCHEMA = "public";
-
   private static final String REDSHIFT_USER;
 
   private static final String REDSHIFT_PASSWORD;
@@ -100,8 +98,6 @@ public class JdbcTpchQueryForAllDatabasesTest {
   private static final String POSTGRES_USER = "postgres";
 
   private static final String POSTGRES_PASSWORD = "";
-
-  private static final String POSTGRES_SCHEMA = "";
 
   static {
     String env = System.getenv("BUILD_ENV");
@@ -173,7 +169,7 @@ public class JdbcTpchQueryForAllDatabasesTest {
 
       // Uncomment below lines to test a specific query
       //      params.clear();
-      //      params.add(new Object[] {database, "22"});
+      //      params.add(new Object[] {database, "1"});
     }
     return params;
   }
@@ -222,7 +218,9 @@ public class JdbcTpchQueryForAllDatabasesTest {
     String connectionString =
         String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
     String verdictConnectionString =
-        String.format("jdbc:verdict:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
+        String.format(
+            "jdbc:verdict:redshift://%s/%s;verdictdbtempschema=%s",
+            REDSHIFT_HOST, REDSHIFT_DATABASE, SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupRedshift(
             connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD, SCHEMA_NAME);


### PR DESCRIPTION
Related to #202 and #194