### PR TITLE
ScrambleMeta passed to SelectQueryCoordinator

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -65,17 +65,21 @@ public class VerdictContext {
     this.conn = new CachedDbmsConnection(conn);
     this.contextId = RandomStringUtils.randomAlphanumeric(5);
     this.options = new VerdictOption();
-    this.metaStore = new CachedScrambleMetaStore(new ScrambleMetaStore(conn, options));
-//    this.scrambleMetaSet = ScrambleMetaStore.retrieve(conn, options);
+    this.metaStore = getCachedMetaStore(conn, options);
   }
 
   public VerdictContext(DbmsConnection conn, VerdictOption options) throws VerdictDBException {
     this.conn = new CachedDbmsConnection(conn);
     this.contextId = RandomStringUtils.randomAlphanumeric(5);
     this.options = options;
-    this.metaStore = new CachedScrambleMetaStore(new ScrambleMetaStore(conn, options));
-//    this.scrambleMetaSet = ScrambleMetaStore.retrieve(conn, options);
+    this.metaStore = getCachedMetaStore(conn, options);
     initialize(options);
+  }
+  
+  private VerdictMetaStore getCachedMetaStore(DbmsConnection conn, VerdictOption option) {
+    CachedScrambleMetaStore metaStore = new CachedScrambleMetaStore(new ScrambleMetaStore(conn, options));
+    metaStore.refreshCache();
+    return metaStore;
   }
   
   /**

--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -116,6 +116,7 @@ public class VerdictContext {
     attemptLoadDriverClass(jdbcConnectionString);
     VerdictOption options = new VerdictOption();
     options.parseProperties(info);
+    options.parseConnectionString(jdbcConnectionString);
     return new VerdictContext(ConcurrentJdbcConnection.create(jdbcConnectionString, info), options);
     //    Connection jdbcConn = DriverManager.getConnection(jdbcConnectionString, info);
     //    return fromJdbcConnection(jdbcConn);

--- a/src/main/java/org/verdictdb/commons/VerdictOption.java
+++ b/src/main/java/org/verdictdb/commons/VerdictOption.java
@@ -16,11 +16,11 @@
 
 package org.verdictdb.commons;
 
-import com.rits.cloning.Cloner;
-
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.rits.cloning.Cloner;
 
 /** Created by Dong Young Yoon on 8/9/18. */
 public class VerdictOption {

--- a/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
@@ -16,6 +16,12 @@
 
 package org.verdictdb.connection;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 
@@ -25,12 +31,12 @@ import org.verdictdb.sqlsyntax.SqlSyntax;
  *
  * @author Yongjoo Park
  */
-public class CachedDbmsConnection extends CachedMetaDataProvider implements DbmsConnection {
+public class CachedDbmsConnection extends DbmsConnection implements MetaDataProvider {
 
   DbmsConnection originalConn;
 
   public CachedDbmsConnection(DbmsConnection conn) {
-    super(conn);
+//    super(conn);
     this.originalConn = conn;
   }
 
@@ -57,5 +63,79 @@ public class CachedDbmsConnection extends CachedMetaDataProvider implements Dbms
   public DbmsConnection copy() {
     CachedDbmsConnection newConn = new CachedDbmsConnection(originalConn.copy());
     return newConn;
+  }
+
+  //  private String defaultSchema = null;
+
+  private List<String> schemaCache = new ArrayList<>();
+
+  private HashMap<String, List<String>> tablesCache = new HashMap<>();
+
+  private HashMap<Pair<String, String>, List<String>> partitionCache = new HashMap<>();
+
+  // Get column name and type
+  private HashMap<Pair<String, String>, List<Pair<String, String>>> columnsCache = new HashMap<>();
+
+  @Override
+  public List<String> getSchemas() throws VerdictDBDbmsException {
+    if (!schemaCache.isEmpty()) {
+      return schemaCache;
+    }
+    schemaCache.addAll(originalConn.getSchemas());
+    return schemaCache;
+  }
+
+  @Override
+  public List<String> getTables(String schema) throws VerdictDBDbmsException {
+    if (tablesCache.containsKey(schema) && !tablesCache.get(schema).isEmpty()) {
+      return tablesCache.get(schema);
+    }
+    tablesCache.put(schema, originalConn.getTables(schema));
+    return tablesCache.get(schema);
+  }
+
+  @Override
+  public List<Pair<String, String>> getColumns(String schema, String table)
+      throws VerdictDBDbmsException {
+    Pair<String, String> key = new ImmutablePair<>(schema, table);
+    if (columnsCache.containsKey(key) && !columnsCache.get(key).isEmpty()) {
+      return columnsCache.get(key);
+    }
+    columnsCache.put(key, originalConn.getColumns(schema, table));
+    return columnsCache.get(key);
+  }
+
+  /**
+   * Only needed for the DBMS that supports partitioning.
+   *
+   * @param schema
+   * @param table
+   * @return
+   * @throws VerdictDBDbmsException
+   */
+  @Override
+  public List<String> getPartitionColumns(String schema, String table)
+      throws VerdictDBDbmsException {
+    //    if (!syntax.doesSupportTablePartitioning()) {
+    //      throw new VerdictDBDbmsException("Database does not support table partitioning");
+    //    }
+    Pair<String, String> key = new ImmutablePair<>(schema, table);
+    if (columnsCache.containsKey(key) && !partitionCache.isEmpty()) {
+      return partitionCache.get(key);
+    }
+    partitionCache.put(key, originalConn.getPartitionColumns(schema, table));
+    return partitionCache.get(key);
+  }
+
+  public String getDefaultSchema() {
+    String schema = originalConn.getDefaultSchema();
+    //    if (defaultSchema == null) {
+    //      defaultSchema = metaProvider.getDefaultSchema();
+    //    }
+    return schema;
+  }
+
+  public void setDefaultSchema(String schema) {
+    originalConn.setDefaultSchema(schema);
   }
 }

--- a/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
@@ -49,6 +49,11 @@ public class CachedDbmsConnection extends DbmsConnection implements MetaDataProv
   public SqlSyntax getSyntax() {
     return originalConn.getSyntax();
   }
+  
+  @Override
+  public void abort() {
+    originalConn.abort();
+  }
 
   @Override
   public void close() {

--- a/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
@@ -131,6 +131,13 @@ public class ConcurrentJdbcConnection extends DbmsConnection {
   public SqlSyntax getSyntax() {
     return getNextConnection().getSyntax();
   }
+  
+  @Override
+  public void abort() {
+    for (JdbcConnection c : connections) {
+      c.abort();
+    }
+  }
 
   @Override
   public void close() {

--- a/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntaxList;
@@ -35,7 +36,7 @@ import org.verdictdb.sqlsyntax.SqlSyntaxList;
  * @author Yongjoo Park
  *
  */
-public class ConcurrentJdbcConnection implements DbmsConnection {
+public class ConcurrentJdbcConnection extends DbmsConnection {
   
   private static final int CONNECTION_POOL_SIZE = 10;
   
@@ -43,12 +44,15 @@ public class ConcurrentJdbcConnection implements DbmsConnection {
   
   private int nextConnectionIndex = 0;
   
+  private VerdictDBLogger logger = VerdictDBLogger.getLogger(getClass());
+  
   public ConcurrentJdbcConnection(List<JdbcConnection> connections) {
     this.connections.addAll(connections);
   }
   
   public ConcurrentJdbcConnection(String url, Properties info, SqlSyntax syntax) 
       throws VerdictDBDbmsException {
+    logger.debug(String.format("Creating %d JDBC connections with this url: " + url, CONNECTION_POOL_SIZE));
     for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
       try {
         Connection c;

--- a/src/main/java/org/verdictdb/connection/DbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/DbmsConnection.java
@@ -16,10 +16,13 @@
 
 package org.verdictdb.connection;
 
+import org.verdictdb.core.sqlobject.SqlConvertible;
 import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.SqlSyntax;
+import org.verdictdb.sqlwriter.QueryToSql;
 
-public interface DbmsConnection extends MetaDataProvider {
+public abstract class DbmsConnection implements MetaDataProvider {
 
   /**
    * Executes a query (or queries). If the result exists, return it.
@@ -27,11 +30,17 @@ public interface DbmsConnection extends MetaDataProvider {
    * <p>If a query includes multiple queries separated by semicolons, issue them separately in
    * order.
    *
-   * @param query
+   * @param sql
    * @return
    * @throws VerdictDBDbmsException
    */
-  public DbmsQueryResult execute(String query) throws VerdictDBDbmsException;
+  public abstract DbmsQueryResult execute(String sql) throws VerdictDBDbmsException;
+  
+  public DbmsQueryResult execute(SqlConvertible query) throws VerdictDBException {
+    String sql = QueryToSql.convert(getSyntax(), query);
+    DbmsQueryResult result = execute(sql);
+    return result;
+  }
 
   //  /**
   //   *
@@ -42,11 +51,11 @@ public interface DbmsConnection extends MetaDataProvider {
   //   */
   //  public int executeUpdate(String query) throws VerdictDBDbmsException;
 
-  public SqlSyntax getSyntax();
+  public abstract SqlSyntax getSyntax();
 
   //  public Connection getConnection();
 
-  public void close();
+  public abstract void close();
 
-  public DbmsConnection copy();
+  public abstract DbmsConnection copy();
 }

--- a/src/main/java/org/verdictdb/connection/DbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/DbmsConnection.java
@@ -56,6 +56,8 @@ public abstract class DbmsConnection implements MetaDataProvider {
   //  public Connection getConnection();
 
   public abstract void close();
+  
+  public abstract void abort();
 
   public abstract DbmsConnection copy();
 }

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -184,9 +184,7 @@ public class JdbcConnection extends DbmsConnection {
   }
 
   public DbmsQueryResult executeSingle(String sql) throws VerdictDBDbmsException {
-
-    VerdictDBLogger logger = VerdictDBLogger.getLogger(this.getClass());
-    logger.debug("Issuing the following query to DBMS: " + sql);
+    log.debug("Issuing the following query to DBMS: " + sql);
 
     try {
       Statement stmt = conn.createStatement();
@@ -204,50 +202,18 @@ public class JdbcConnection extends DbmsConnection {
       stmt.close();
       return jrs;
     } catch (SQLException e) {
-//      e.printStackTrace();
-      //      logger.debug(StackTraceReader.stackTrace2String(e));
-      throw new VerdictDBDbmsException(e.getMessage());
+      if (e.getMessage().contains("Operation is canceled")) {
+        // do nothing
+        return null;
+      } else {
+        throw new VerdictDBDbmsException(e.getMessage());
+      }
     }
   }
-
-  //  @Override
-  //  public DbmsQueryResult getResult() {
-  //    return jrs;
-  //  }
 
   public DbmsQueryResult executeQuery(String sql) throws VerdictDBDbmsException {
     return execute(sql);
   }
-
-  //  @Override
-  //  public DbmsQueryResult executeQuery(String query) throws VerdictDBDbmsException {
-  //    System.out.println("About to issue this query: " + query);
-  //    try {
-  //      Statement stmt = conn.createStatement();
-  //      ResultSet rs = stmt.executeQuery(query);
-  //      JdbcQueryResult jrs = new JdbcQueryResult(rs);
-  //      rs.close();
-  //      stmt.close();
-  //      return jrs;
-  //    } catch (SQLException e) {
-  //      throw new VerdictDBDbmsException(e.getMessage());
-  //    }
-  //  }
-  //
-  //  @Override
-  //  public int executeUpdate(String query) throws VerdictDBDbmsException {
-  //    System.out.println("About to issue this query: " + query);
-  //    try {
-  //      Statement stmt = conn.createStatement();
-  //      int r = stmt.executeUpdate(query);
-  //      stmt.close();
-  //      return r;
-  //    } catch (SQLException e) {
-  //      throw new VerdictDBDbmsException(e);
-  ////      e.printStackTrace();
-  ////      return 0;
-  //    }
-  //  }
 
   @Override
   public SqlSyntax getSyntax() {
@@ -307,9 +273,6 @@ public class JdbcConnection extends DbmsConnection {
         type = queryResult.getString(syntax.getColumnTypeColumnIndex());
       }
       type = type.toLowerCase();
-
-      //        // remove the size of type
-      //        type = type.replaceAll("\\(.*\\)", "");
 
       columns.add(
           new ImmutablePair<>(queryResult.getString(syntax.getColumnNameColumnIndex()), type));

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -41,7 +41,7 @@ import org.verdictdb.sqlsyntax.SqlSyntaxList;
 
 import com.google.common.collect.Sets;
 
-public class JdbcConnection implements DbmsConnection {
+public class JdbcConnection extends DbmsConnection {
 
   Connection conn;
 
@@ -76,11 +76,6 @@ public class JdbcConnection implements DbmsConnection {
     this.conn = conn;
     try {
       this.currentSchema = conn.getSchema();
-      //      if (syntax instanceof PostgresqlSyntax || syntax instanceof RedshiftSyntax) {
-      //
-      //      } else {
-      //        this.currentSchema = conn.getCatalog();
-      //      }
     } catch (SQLException e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -255,14 +255,16 @@ public class JdbcConnection implements DbmsConnection {
   }
 
   @Override
-  public List<String> getTables(String schema) throws VerdictDBDbmsException {
+  public List<String> getTables(String schema) {
     List<String> tables = new ArrayList<>();
-    DbmsQueryResult queryResult = executeQuery(syntax.getTableCommand(schema));
-
-    while (queryResult.next()) {
-      tables.add(queryResult.getString(syntax.getTableNameColumnIndex()));
+    try {
+      DbmsQueryResult queryResult = executeQuery(syntax.getTableCommand(schema));
+      while (queryResult.next()) {
+        tables.add(queryResult.getString(syntax.getTableNameColumnIndex()));
+      }
+    } catch (VerdictDBDbmsException e) {
+      log.debug(e.getMessage());
     }
-
     return tables;
   }
 

--- a/src/main/java/org/verdictdb/connection/SparkConnection.java
+++ b/src/main/java/org/verdictdb/connection/SparkConnection.java
@@ -137,6 +137,11 @@ public class SparkConnection extends DbmsConnection {
   public SqlSyntax getSyntax() {
     return syntax;
   }
+  
+  @Override
+  public void abort() {
+    
+  }
 
   @Override
   public void close() {

--- a/src/main/java/org/verdictdb/connection/SparkConnection.java
+++ b/src/main/java/org/verdictdb/connection/SparkConnection.java
@@ -28,7 +28,7 @@ import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.sqlsyntax.SparkSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 
-public class SparkConnection implements DbmsConnection {
+public class SparkConnection extends DbmsConnection {
 
   SparkSession sc;
 

--- a/src/main/java/org/verdictdb/coordinator/Coordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/Coordinator.java
@@ -1,0 +1,7 @@
+package org.verdictdb.coordinator;
+
+public interface Coordinator {
+
+  public void abort();
+  
+}

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -16,13 +16,18 @@
 
 package org.verdictdb.coordinator;
 
+import static org.verdictdb.coordinator.VerdictSingleResultFromListData.createWithSingleColumn;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.VerdictContext;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.DbmsConnection;
-import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.resulthandler.ExecutionResultReader;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.sqlobject.BaseTable;
@@ -35,14 +40,6 @@ import org.verdictdb.parser.VerdictSQLParser;
 import org.verdictdb.parser.VerdictSQLParserBaseVisitor;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationGen;
-import org.verdictdb.sqlsyntax.PostgresqlSyntax;
-import org.verdictdb.sqlsyntax.RedshiftSyntax;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.verdictdb.coordinator.VerdictSingleResultFromListData.createWithSingleColumn;
 
 /**
  * Stores the context for a single query execution. Includes both scrambling query and select query.
@@ -106,7 +103,7 @@ public class ExecutionContext {
     if (queryType.equals(QueryType.select)) {
       LOG.debug("Query type: select");
       SelectQueryCoordinator coordinator =
-          new SelectQueryCoordinator(context.getCopiedConnection(), options);
+          new SelectQueryCoordinator(context.getCopiedConnection(), context.getScrambleMetaSet(), options);
       ExecutionResultReader reader = coordinator.process(query, queryContext);
       VerdictResultStream stream = new VerdictResultStreamFromExecutionResultReader(reader, this);
       return stream;

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -284,6 +284,7 @@ public class ExecutionContext {
   public void abort() {
     if (runningCoordinator != null) {
       runningCoordinator.abort();
+      runningCoordinator = null;
     }
   }
 

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -120,6 +120,7 @@ public class ExecutionContext {
 
       VerdictSingleResult result = stream.next();
       stream.close();
+      abort();
       return result;
     }
   }

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -265,24 +265,30 @@ public class ExecutionContext {
               "%s_%s_%d",
               VerdictOption.getVerdictTempTablePrefix(), context.getContextId(), this.serialNumber);
       List<String> tempTableList = new ArrayList<>();
-
-      DbmsQueryResult rs;
-
-      if (conn.getSyntax() instanceof RedshiftSyntax
-          || conn.getSyntax() instanceof PostgresqlSyntax) {
-        rs =
-            conn.execute(
-                String.format(
-                    "SELECT * FROM information_schema.tables WHERE table_schema = '%s'", schema));
-      } else {
-        rs = conn.execute(String.format("show tables in %s", schema));
-      }
-      while (rs.next()) {
-        String tableName = rs.getString(0);
+      
+      List<String> allTempTables = conn.getTables(schema);
+      for (String tableName : allTempTables) {
         if (tableName.startsWith(tempTablePrefix)) {
           tempTableList.add(tableName);
         }
       }
+
+//      DbmsQueryResult rs;
+//      if (conn.getSyntax() instanceof RedshiftSyntax
+//          || conn.getSyntax() instanceof PostgresqlSyntax) {
+//        rs =
+//            conn.execute(
+//                String.format(
+//                    "SELECT * FROM information_schema.tables WHERE table_schema = '%s'", schema));
+//      } else {
+//        rs = conn.execute(String.format("show tables in %s", schema));
+//      }
+//      while (rs.next()) {
+//        String tableName = rs.getString(0);
+//        if (tableName.startsWith(tempTablePrefix)) {
+//          tempTableList.add(tableName);
+//        }
+//      }
 
       for (String tempTable : tempTableList) {
         conn.execute(String.format("DROP TABLE IF EXISTS %s.%s", schema, tempTable));

--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -16,6 +16,10 @@
 
 package org.verdictdb.coordinator;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.commons.VerdictOption;
@@ -29,16 +33,18 @@ import org.verdictdb.core.querying.QueryExecutionPlanFactory;
 import org.verdictdb.core.querying.ola.AsyncQueryExecutionPlan;
 import org.verdictdb.core.resulthandler.ExecutionResultReader;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
-import org.verdictdb.core.sqlobject.*;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.ColumnOp;
+import org.verdictdb.core.sqlobject.JoinTable;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.SubqueryColumn;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.metastore.ScrambleMetaStore;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlreader.ScrambleTableReplacer;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 
 public class SelectQueryCoordinator {
 

--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -43,7 +43,6 @@ import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.SubqueryColumn;
 import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
-import org.verdictdb.metastore.ScrambleMetaStore;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlreader.ScrambleTableReplacer;

--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -31,6 +31,7 @@ import org.verdictdb.connection.StaticMetaData;
 import org.verdictdb.core.execplan.ExecutablePlanRunner;
 import org.verdictdb.core.querying.QueryExecutionPlan;
 import org.verdictdb.core.querying.QueryExecutionPlanFactory;
+import org.verdictdb.core.querying.QueryExecutionPlanSimplifier;
 import org.verdictdb.core.querying.ola.AsyncQueryExecutionPlan;
 import org.verdictdb.core.resulthandler.ExecutionResultReader;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
@@ -118,7 +119,7 @@ public class SelectQueryCoordinator implements Coordinator {
 
     // simplify the plan
     //    QueryExecutionPlan simplifiedAsyncPlan = QueryExecutionPlanSimplifier.simplify(asyncPlan);
-    //    QueryExecutionPlanSimplifier.simplify2(asyncPlan);
+    QueryExecutionPlanSimplifier.simplify2(asyncPlan);
 
     //    asyncPlan.getRootNode().print();
 
@@ -146,12 +147,12 @@ public class SelectQueryCoordinator implements Coordinator {
     // if the plan does not include any aggregates, this operation should not alter the original
     // plan.
     QueryExecutionPlan asyncPlan = AsyncQueryExecutionPlan.create(plan);
-    
-    log.debug(asyncPlan.getRoot().getStructure());
 
     // simplify the plan
     //    QueryExecutionPlan simplifiedAsyncPlan = QueryExecutionPlanSimplifier.simplify(asyncPlan);
-    //    QueryExecutionPlanSimplifier.simplify2(asyncPlan);
+    QueryExecutionPlanSimplifier.simplify2(asyncPlan);
+    
+    log.debug(asyncPlan.getRoot().getStructure());
 
     // execute the plan
     planRunner = new ExecutablePlanRunner(conn, asyncPlan);
@@ -175,11 +176,11 @@ public class SelectQueryCoordinator implements Coordinator {
     NonValidatingSQLParser sqlToRelation = new NonValidatingSQLParser();
     SelectQuery relation = (SelectQuery) sqlToRelation.toRelation(query);
     MetaDataProvider metaData = createMetaDataFor(relation);
-    ScrambleMetaStore metaStore = new ScrambleMetaStore(conn, options);
+//    ScrambleMetaStore metaStore = new ScrambleMetaStore(conn, options);
     RelationStandardizer gen = new RelationStandardizer(metaData, conn.getSyntax());
     relation = gen.standardize(relation);
 
-    ScrambleTableReplacer replacer = new ScrambleTableReplacer(metaStore);
+    ScrambleTableReplacer replacer = new ScrambleTableReplacer(scrambleMetaSet);
     replacer.replace(relation);
 
     return relation;

--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -30,6 +30,7 @@ import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.querying.ExecutableNodeBase;
 import org.verdictdb.core.sqlobject.SqlConvertible;
+import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
 import org.verdictdb.sqlwriter.QueryToSql;
@@ -216,7 +217,15 @@ public class ExecutableNodeRunner implements Runnable {
     DbmsQueryResult intermediate = null;
     if (sqlObj != null) {
       String sql = QueryToSql.convert(conn.getSyntax(), sqlObj);
-      intermediate = conn.execute(sql);
+      try {
+        intermediate = conn.execute(sql);
+      } catch (VerdictDBDbmsException e) {
+        if (isAborted) {
+          // the errors from the underlying dbms are expected if the query is cancelled.
+        } else {
+          throw e;
+        }
+      }
     }
     ExecutionInfoToken token = node.createToken(intermediate);
 

--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.connection.DbmsConnection;
@@ -177,6 +178,13 @@ public class ExecutableNodeRunner implements Runnable {
     if (sqlObj != null) {
       String sql = QueryToSql.convert(conn.getSyntax(), sqlObj);
       intermediate = conn.execute(sql);
+      
+//      // Give database some time to ensure ACID
+//      try {
+//        TimeUnit.MILLISECONDS.sleep(10);
+//      } catch (InterruptedException e) {
+//        e.printStackTrace();
+//      }
     }
     ExecutionInfoToken token = node.createToken(intermediate);
 

--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.connection.DbmsConnection;

--- a/src/main/java/org/verdictdb/core/querying/CreateTableAsSelectNode.java
+++ b/src/main/java/org/verdictdb/core/querying/CreateTableAsSelectNode.java
@@ -52,7 +52,7 @@ public class CreateTableAsSelectNode extends QueryNodeWithPlaceHolders {
   public IdCreator getNamer() {
     return namer;
   }
-
+  
   public void setNamer(IdCreator namer) {
     this.namer = namer;
   }
@@ -61,6 +61,11 @@ public class CreateTableAsSelectNode extends QueryNodeWithPlaceHolders {
     partitionColumns.add(column);
   }
 
+  
+  /**
+   * The namer is used for each token to handle the case that the downstream node passes multiple
+   * tokens (e.g., AsyncAggNode).
+   */
   @Override
   public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {
     super.createQuery(tokens);

--- a/src/main/java/org/verdictdb/core/querying/ExecutableNodeBase.java
+++ b/src/main/java/org/verdictdb/core/querying/ExecutableNodeBase.java
@@ -301,20 +301,27 @@ public class ExecutableNodeBase implements ExecutableNode, Serializable {
   }
 
   public void print() {
-    print(0);
+    System.out.println(print(0));
+  }
+  
+  public String getStructure() {
+    return print(0);
   }
 
-  void print(int indentSpace) {
+  private String print(int indentSpace) {
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < indentSpace; i++) {
       builder.append(" ");
     }
     builder.append(this.toString());
-    System.out.println(builder.toString());
+    builder.append("\n");
+//    System.out.println(builder.toString());
 
     for (ExecutableNodeBase dep : getExecutableNodeBaseDependents()) {
-      dep.print(indentSpace + 2);
+      builder.append(dep.print(indentSpace + 2));
     }
+    
+    return builder.toString();
   }
 
   public AggMeta getAggMeta() {
@@ -353,7 +360,7 @@ public class ExecutableNodeBase implements ExecutableNode, Serializable {
     return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
         .append("subscriberCount", subscribers.size())
         //        .append("sources", sources)
-        .append("sourcCount", sources.size())
+        .append("sourceCount", sources.size())
         //        .append("channels", channels)
         //        .append("channels", channels)
         .toString();

--- a/src/main/java/org/verdictdb/core/querying/PlaceHolderRecord.java
+++ b/src/main/java/org/verdictdb/core/querying/PlaceHolderRecord.java
@@ -1,0 +1,27 @@
+package org.verdictdb.core.querying;
+
+import java.io.Serializable;
+
+import org.verdictdb.core.sqlobject.BaseTable;
+
+public class PlaceHolderRecord implements Serializable {
+
+  private static final long serialVersionUID = -6893613573198545114L;
+
+  private BaseTable placeholderTable;
+  
+  private int subscriptionChannel;
+  
+  public PlaceHolderRecord(BaseTable placeholderTable, int subscriptionChannel) {
+    this.placeholderTable = placeholderTable;
+    this.subscriptionChannel = subscriptionChannel;
+  }
+  
+  public BaseTable getPlaceholderTable() {
+    return placeholderTable;
+  }
+  
+  public int getSubscriptionChannel() {
+    return subscriptionChannel;
+  }
+}

--- a/src/main/java/org/verdictdb/core/querying/QueryExecutionPlanFactory.java
+++ b/src/main/java/org/verdictdb/core/querying/QueryExecutionPlanFactory.java
@@ -16,13 +16,23 @@
 
 package org.verdictdb.core.querying;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.coordinator.QueryContext;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
-import org.verdictdb.core.sqlobject.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.AliasedColumn;
+import org.verdictdb.core.sqlobject.AsteriskColumn;
+import org.verdictdb.core.sqlobject.BaseColumn;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.ColumnOp;
+import org.verdictdb.core.sqlobject.JoinTable;
+import org.verdictdb.core.sqlobject.SelectItem;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.SubqueryColumn;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 
 public class QueryExecutionPlanFactory {
 

--- a/src/main/java/org/verdictdb/core/querying/QueryExecutionPlanFactory.java
+++ b/src/main/java/org/verdictdb/core/querying/QueryExecutionPlanFactory.java
@@ -105,8 +105,8 @@ public class QueryExecutionPlanFactory {
         selectAll.createPlaceHolderTable("t");
     SelectQuery selectQuery =
         SelectQuery.create(new AsteriskColumn(), baseAndSubscriptionTicket.getLeft());
-    selectQuery.addOrderby(query.getOrderby());
-    if (query.getLimit().isPresent()) selectQuery.addLimit(query.getLimit().get());
+//    selectQuery.addOrderby(query.getOrderby());
+//    if (query.getLimit().isPresent()) selectQuery.addLimit(query.getLimit().get());
     selectAll.setSelectQuery(selectQuery);
 
     if (query.isSupportedAggregate()) {
@@ -126,6 +126,8 @@ public class QueryExecutionPlanFactory {
       IdCreator idCreator, SelectQuery query) {
     AggExecutionNode node = new AggExecutionNode(idCreator, null);
     convertSubqueriesToDependentNodes(query, node);
+//    query.addOrderby(query.getOrderby());
+//  if (query.getLimit().isPresent()) selectQuery.addLimit(query.getLimit().get());
     node.setSelectQuery(query);
     return node;
   }

--- a/src/main/java/org/verdictdb/core/querying/QueryNodeBase.java
+++ b/src/main/java/org/verdictdb/core/querying/QueryNodeBase.java
@@ -56,39 +56,7 @@ public class QueryNodeBase extends ExecutableNodeBase {
 
   public void setSelectQuery(SelectQuery query) {
     this.selectQuery = query;
-    //    this.selectQuery = query.deepcopy(); // dyoon: this seems to cause problem in other unit
-    // tests.
   }
-  
-//  /**
-//   * Even in the case where multiple threads access this instance concurrently, the objects stored
-//   * using this method distinguish the original thread, thus can retrieve the correct one.
-//   *
-//   * @param key The key of the object to store
-//   * @param value The object to store
-//   */
-//  protected void storeObjectThreadSafely(String key, Object value) {
-//    long threadId = Thread.currentThread().getId();
-//    System.out.println("Stored for the thread: " + threadId);
-//    if (threadSafeStorage.containsKey(threadId) == false) {
-//      Map<String, Object> distinctStorage = new HashMap<>();
-//      threadSafeStorage.put(threadId, distinctStorage);
-//    }
-//
-//    final Map<String, Object> distinctStorage = threadSafeStorage.get(threadId);
-//    distinctStorage.put(key, value);
-//  }
-//
-//  protected Object retrieveStoredObjectThreadSafely(String key) {
-//    long threadId = Thread.currentThread().getId();
-//    System.out.println("Retrieved for the thread: " + threadId);
-//    if (threadSafeStorage.containsKey(threadId) == false) {
-//      return null;
-//    }
-//
-//    final Map<String, Object> distinctStorage = threadSafeStorage.get(threadId);
-//    return distinctStorage.get(key);
-//  }
 
   @Override
   public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {

--- a/src/main/java/org/verdictdb/core/querying/QueryNodeWithPlaceHolders.java
+++ b/src/main/java/org/verdictdb/core/querying/QueryNodeWithPlaceHolders.java
@@ -195,7 +195,7 @@ public abstract class QueryNodeWithPlaceHolders extends QueryNodeBase {
    * @return The removed record
    */
   public PlaceHolderRecord removePlaceholderRecordForChannel(int channel) {
-    int indexToRemove = 0;
+    int indexToRemove = -1;
     for (int i = 0; i < placeholderRecords.size(); i++) {
       PlaceHolderRecord record = placeholderRecords.get(i);
       if (record.getSubscriptionChannel() == channel) {
@@ -203,8 +203,12 @@ public abstract class QueryNodeWithPlaceHolders extends QueryNodeBase {
         break;
       }
     }
-    PlaceHolderRecord removed = placeholderRecords.remove(indexToRemove);
-    return removed;
+    if (indexToRemove >= 0) {
+      PlaceHolderRecord removed = placeholderRecords.remove(indexToRemove);
+      return removed;
+    } else {
+      return null;
+    }
   }
   
   public void addPlaceholderRecord(PlaceHolderRecord record) {

--- a/src/main/java/org/verdictdb/core/querying/QueryNodeWithPlaceHolders.java
+++ b/src/main/java/org/verdictdb/core/querying/QueryNodeWithPlaceHolders.java
@@ -272,27 +272,9 @@ public abstract class QueryNodeWithPlaceHolders extends QueryNodeBase {
   }
 }
 
-class PlaceHolderRecord implements Serializable {
-
-  private BaseTable placeholderTable;
-  
-  private int subscriptionChannel;
-  
-  public PlaceHolderRecord(BaseTable placeholderTable, int subscriptionChannel) {
-    this.placeholderTable = placeholderTable;
-    this.subscriptionChannel = subscriptionChannel;
-  }
-  
-  public BaseTable getPlaceholderTable() {
-    return placeholderTable;
-  }
-  
-  public int getSubscriptionChannel() {
-    return subscriptionChannel;
-  }
-}
-
 class UniquePlaceholderNameCreator implements Serializable {
+
+  private static final long serialVersionUID = -1364930156601816114L;
 
   private int identifier = 0;
   

--- a/src/main/java/org/verdictdb/core/querying/SelectAllExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/SelectAllExecutionNode.java
@@ -31,6 +31,8 @@ import org.verdictdb.exception.VerdictDBValueException;
 /** @author Yongjoo Park */
 public class SelectAllExecutionNode extends QueryNodeWithPlaceHolders {
 
+  private static final long serialVersionUID = -4794780058649322912L;
+
   public SelectAllExecutionNode(IdCreator idCreator, SelectQuery query) {
     super(idCreator, query);
   }
@@ -78,24 +80,6 @@ public class SelectAllExecutionNode extends QueryNodeWithPlaceHolders {
     token.setKeyValue("queryResult", result);
     return token;
   }
-
-  //  @Override
-  //  public ExecutionInfoToken executeNode(DbmsConnection conn, List<ExecutionInfoToken>
-  // downstreamResults)
-  //      throws VerdictDBException {
-  //    super.executeNode(conn, downstreamResults);
-  //    try {
-  //      String sql = QueryToSql.convert(conn.getSyntax(), selectQuery);
-  //      DbmsQueryResult queryResult = conn.executeQuery(sql);
-  //      ExecutionInfoToken result = new ExecutionInfoToken();
-  //      result.setKeyValue("queryResult", queryResult);
-  //      return result;
-  //
-  //    } catch (VerdictDBException e) {
-  //      e.printStackTrace();
-  //    }
-  //    return ExecutionInfoToken.empty();
-  //  }
 
   @Override
   public ExecutableNodeBase deepcopy() {

--- a/src/main/java/org/verdictdb/core/querying/TempIdCreatorInScratchpadSchema.java
+++ b/src/main/java/org/verdictdb/core/querying/TempIdCreatorInScratchpadSchema.java
@@ -16,13 +16,13 @@
 
 package org.verdictdb.core.querying;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.verdictdb.coordinator.QueryContext;
-
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.verdictdb.coordinator.QueryContext;
 
 public class TempIdCreatorInScratchpadSchema implements IdCreator, Serializable {
 

--- a/src/main/java/org/verdictdb/core/querying/ola/AggMeta.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/AggMeta.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -115,7 +116,11 @@ public class AggMeta implements Serializable {
     // create individual tier number sets; this will be the argument for the cartesian product
     List<Set<Integer>> tierLists = new ArrayList<>();
     for (int c : tierCounts) {
-      Set<Integer> tiers = Ranges.closedOpen(0, c).asSet(DiscreteDomains.integers());
+//      Set<Integer> tiers = Ranges.closedOpen(0, c).asSet(DiscreteDomains.integers());
+      Set<Integer> tiers = new TreeSet<>();
+      for (int i = 0; i < c; i++) {
+        tiers.add(i);
+      }
       tierLists.add(tiers);
     }
     Set<List<Integer>> product = Sets.cartesianProduct(tierLists);

--- a/src/main/java/org/verdictdb/core/querying/ola/AsyncAggExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/AsyncAggExecutionNode.java
@@ -158,23 +158,17 @@ public class AsyncAggExecutionNode extends ProjectionNode {
 
   @Override
   public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {
-    super.createQuery(tokens);
+//    super.createQuery(tokens);
+    
+//    System.out.println("Starts the processing of AsyncAggNode.");
+//    System.out.println(selectQuery);
 
     ExecutionInfoToken token = tokens.get(0);
     AggMeta sourceAggMeta = (AggMeta) token.getValue("aggMeta");
 
     // First, calculate the scale factor and use it to replace the scale factor placeholder
-    //    HashMap<List<Integer>, Double> scaleFactor =
-    //        calculateScaleFactor(sourceAggMeta, scrambledTableTierInfo);
-
     List<Pair<UnnamedColumn, Double>> conditionToScaleFactor =
         composeScaleFactorForTierCombinations(sourceAggMeta, INNER_RAW_AGG_TABLE_ALIAS);
-
-//    // we store the original aggColumns to restore it later.
-//    List<ColumnOp> clonedAggColumns = new ArrayList<>();
-//    for (ColumnOp col : aggColumns) {
-//      clonedAggColumns.add(col.deepcopy());
-//    }
 
     // update the agg column scaling factor
     List<UnnamedColumn> scalingOperands = new ArrayList<>();
@@ -190,81 +184,11 @@ public class AsyncAggExecutionNode extends ProjectionNode {
       aggcol.setOperand(0, scalingColumn);
     }
 
-    //    // single-tier case
-    //    if (scaleFactor.size() == 1) {
-    //      // Substitute the scale factor
-    //      Double s = (Double) (scaleFactor.values().toArray())[0];
-    //      for (ColumnOp col : aggColumns) {
-    //        col.setOperand(0, ConstantColumn.valueOf(String.format("%.16f", s)));
-    //      }
-    //    }
-    //    // multiple-tiers case
-    //    else {
-    //      // If it has multiple tiers, we need to rewrite the multiply column into when-then-else column
-    //      for (ColumnOp col : aggColumns) {
-    //        //        String alias = ((BaseColumn) col.getOperand(1)).getColumnName();
-    //        col.setOpType("casewhen");
-    //        List<UnnamedColumn> operands = new ArrayList<>();
-    //        for (Map.Entry<List<Integer>, Double> entry : scaleFactor.entrySet()) {
-    //          List<Integer> tierPermutation = entry.getKey();
-    //          UnnamedColumn condition = generateCaseCondition(tierPermutation, scrambledTableTierInfo);
-    //          operands.add(condition);
-    //          ColumnOp multiply =
-    //              new ColumnOp(
-    //                  "multiply",
-    //                  Arrays.asList(
-    //                      ConstantColumn.valueOf(String.format("%.16f", entry.getValue())),
-    //                      col.getOperand(1)));
-    //          operands.add(multiply);
-    //        }
-    //        operands.add(ConstantColumn.valueOf(0));
-    //        col.setOperand(operands);
-    //      }
-    //    }
-
-    // If it has multiple tiers, we need to sum up the result
-    // We treat both single-tier and multi-tier cases simultaneously here to make alias management
-    // easier.
-    //      SelectQuery query = sumUpTierGroup(selectQuery.deepcopy(), sourceAggMeta);
-
-//    // Restore the original aggColumns
-//    for (int i = 0; i < clonedAggColumns.size(); i++) {
-//      ColumnOp cloned = clonedAggColumns.get(i);
-//      ColumnOp originalReference = aggColumns.get(i);
-//      originalReference.setOpType(cloned.getOpType());
-//      originalReference.setOperand(cloned.getOperands());
-//    }
-
-    //    if (multipleTierTableTierInfo.size() > 0) {
-    //      query = sumUpTierGroup(
-    //          (SelectQuery) aggColumnsAndQuery.getRight(), ((AggMeta) token.getValue("aggMeta")));
-    //    } else {
-    //      query = (SelectQuery) aggColumnsAndQuery.getRight();
-    //    }
-
-    //    Pair<String, String> tempTableFullName = getNamer().generateTempTableName();
-    //    newTableSchemaName = tempTableFullName.getLeft();
-    //    newTableName = tempTableFullName.getRight();
     selectQuery = replaceWithOriginalSelectList(selectQuery, sourceAggMeta);
+    
+//    System.out.println("Finished composing a query in AsyncAggNode.");
+//    System.out.println(selectQuery);
 
-    //    // TODO: this logic should have been placed in the root
-    //    if (selectQuery != null) {
-    //      if (!selectQuery.getGroupby().isEmpty() && selectQuery.getHaving().isPresent()) {
-    //        createTableQuery.addGroupby(selectQuery.getGroupby());
-    //      }
-    //      if (!selectQuery.getOrderby().isEmpty()) {
-    //        createTableQuery.addOrderby(selectQuery.getOrderby());
-    //      }
-    //      if (selectQuery.getHaving().isPresent()) {
-    //        createTableQuery.addHavingByAnd(selectQuery.getHaving().get());
-    //      }
-    //      if (selectQuery.getLimit().isPresent()) {
-    //        createTableQuery.addLimit(selectQuery.getLimit().get());
-    //      }
-    //    }
-
-    //    CreateTableAsSelectQuery createQuery =
-    //        new CreateTableAsSelectQuery(newTableSchemaName, newTableName, createTableQuery);
     return super.createQuery(tokens);
   }
 

--- a/src/main/java/org/verdictdb/core/querying/ola/AsyncQueryExecutionPlan.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/AsyncQueryExecutionPlan.java
@@ -100,18 +100,9 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
     for (int i = 0; i < aggBlocks.size(); i++) {
       // this node block contains the links to those nodes belonging to this block.
       AggExecutionNodeBlock nodeBlock = aggBlocks.get(i);
-//      SelectQuery originalQuery = null;
-//      if (nodeBlock.getBlockRootNode() instanceof AggExecutionNode) {
-//        originalQuery = ((AggExecutionNode) nodeBlock.getBlockRootNode()).getSelectQuery();
-//      }
       
       ExecutableNodeBase oldNode = nodeBlock.getBlockRootNode();
-      //      ExecutableNodeBase newNode = nodeBlock.convertToProgressiveAgg(scrambleMeta);
       ExecutableNodeBase newNode = convertToProgressiveAgg(scrambleMeta, nodeBlock);
-      
-//      if (newNode instanceof AsyncAggExecutionNode && originalQuery != null) {
-//        ((AsyncAggExecutionNode) newNode).setSelectQuery(originalQuery);
-//      }
       
       List<ExecutableNodeBase> parents = oldNode.getExecutableNodeBaseParents();
       for (ExecutableNodeBase parent : parents) {
@@ -135,10 +126,11 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
    * <p>Basically aggregate subqueries are blocking operations while others operations are divided
    * into smaller- scale operations (which involve different portions of data).</p>
    *
-   * @param scrambleMeta
-   * @param aggNodeBlock
-   * @return Returns the root of the multiple aggregation nodes (each of which involves different
-   *     combinations of partitions)
+   * @param scrambleMeta The metadata about the scrambled tables.
+   * @param aggNodeBlock A set of the links to the nodes that will be processed in the asynchronous 
+   *                     manner.
+   * @return Returns     The root of the multiple aggregation nodes (each of which involves 
+   *                     different combinations of partitions)
    * @throws VerdictDBValueException
    */
   public ExecutableNodeBase convertToProgressiveAgg(
@@ -245,12 +237,7 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
 
     // Fourth, re-link the subscription relationship for the new AsyncAggNode
     ExecutableNodeBase newRoot =
-        AsyncAggExecutionNode.create(idCreator, individualAggNodes, combiners, scrambleMeta);
-    
-    // this newRoot must use the 
-    
-//    // Set hashmap of tier column alias for AsyncAggNode
-//    setTierColumnAlias((AsyncAggExecutionNode) newRoot);
+        AsyncAggExecutionNode.create(idCreator, individualAggNodes, combiners, scrambleMeta, aggNodeBlock);
 
     // Finally remove the old subscription information: old copied node -> still used old node
     for (Pair<ExecutableNodeBase, ExecutableNodeBase> parentToSource : oldSubscriptionInformation) {

--- a/src/main/java/org/verdictdb/core/querying/simplifier/DirectRetrievalExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/simplifier/DirectRetrievalExecutionNode.java
@@ -1,0 +1,176 @@
+package org.verdictdb.core.querying.simplifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.verdictdb.connection.DbmsQueryResult;
+import org.verdictdb.core.execplan.ExecutionInfoToken;
+import org.verdictdb.core.querying.CreateTableAsSelectNode;
+import org.verdictdb.core.querying.ExecutableNodeBase;
+import org.verdictdb.core.querying.PlaceHolderRecord;
+import org.verdictdb.core.querying.QueryNodeBase;
+import org.verdictdb.core.querying.QueryNodeWithPlaceHolders;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.ColumnOp;
+import org.verdictdb.core.sqlobject.JoinTable;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.SqlConvertible;
+import org.verdictdb.core.sqlobject.SubqueryColumn;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
+import org.verdictdb.exception.VerdictDBException;
+
+import com.google.common.base.Optional;
+
+public class DirectRetrievalExecutionNode extends QueryNodeWithPlaceHolders {
+
+  private static final long serialVersionUID = -561220173745897906L;
+  
+  private QueryNodeWithPlaceHolders parentNode;
+  
+  private CreateTableAsSelectNode childNode;
+
+  public DirectRetrievalExecutionNode(
+      SelectQuery selectQuery,
+      QueryNodeWithPlaceHolders parent,
+      CreateTableAsSelectNode child) {
+    super(parent.getId(), selectQuery);
+    parentNode = parent;
+    childNode = child;
+    
+    for (PlaceHolderRecord record : parentNode.getPlaceholderRecords()) {
+      addPlaceholderRecord(record);
+    }
+    for (PlaceHolderRecord record : childNode.getPlaceholderRecords()) {
+      addPlaceholderRecord(record);
+    }
+  }
+  
+  public static DirectRetrievalExecutionNode create(
+      QueryNodeWithPlaceHolders parent,
+      CreateTableAsSelectNode child) {
+    
+    SelectQuery parentQuery = parent.getSelectQuery();
+    
+    // find place holders in the parent query and replace with the child query
+    int childChannel = parent.getChannelForSource(child);
+    PlaceHolderRecord placeHolderToRemove = parent.removePlaceholderRecordForChannel(childChannel);
+    BaseTable baseTableToRemove = placeHolderToRemove.getPlaceholderTable();
+    
+    // replace in the source list
+    List<AbstractRelation> parentFromList = parentQuery.getFromList();
+    List<AbstractRelation> newParentFromList = new ArrayList<>();
+    for (AbstractRelation originalSource : parentFromList) {
+      AbstractRelation newSource = consolidateSource(originalSource, child, baseTableToRemove);
+      newParentFromList.add(newSource);
+    }
+    parentQuery.setFromList(newParentFromList);
+    
+    // Filter: replace the placeholder BaseTable (in the filter list) with
+    // the SelectQuery of the child
+    Optional<UnnamedColumn> parentFilterOptional = parentQuery.getFilter();
+    if (parentFilterOptional.isPresent()) {
+      UnnamedColumn originalFilter = parentFilterOptional.get();
+      UnnamedColumn newFilter = consolidateFilter(originalFilter, child, baseTableToRemove);
+      parentQuery.clearFilter();
+      parentQuery.addFilterByAnd(newFilter);
+    }
+    
+    DirectRetrievalExecutionNode node = 
+        new DirectRetrievalExecutionNode(parentQuery, parent, child);
+    return node;
+  }
+  
+  /**
+   * May consonlidate a single source with `child`. This is a helper function for simplify2().
+   *
+   * @param originalSource The original source
+   * @param child The child node
+   * @param baseTableToRemove The placeholder to be replaced
+   * @return A new source
+   */
+  private static AbstractRelation consolidateSource(
+      AbstractRelation originalSource, ExecutableNodeBase child, BaseTable baseTableToRemove) {
+  
+    // exception
+    if (!(child instanceof QueryNodeBase)) {
+      return originalSource;
+    }
+    
+    SelectQuery childQuery = ((QueryNodeBase) child).getSelectQuery();
+    
+    if (originalSource instanceof BaseTable) {
+      BaseTable baseTableSource = (BaseTable) originalSource;
+      if (baseTableSource.equals(baseTableToRemove)) {
+        childQuery.setAliasName(baseTableToRemove.getAliasName().get());
+        return childQuery;
+      } else {
+        return originalSource;
+      }
+    } else if (originalSource instanceof JoinTable) {
+      JoinTable joinTableSource = (JoinTable) originalSource;
+      List<AbstractRelation> joinSourceList = joinTableSource.getJoinList();
+      List<AbstractRelation> newJoinSourceList = new ArrayList<>();
+      for (AbstractRelation joinSource : joinSourceList) {
+        newJoinSourceList.add(consolidateSource(joinSource, child, baseTableToRemove));
+      }
+      joinTableSource.setJoinList(newJoinSourceList);
+      return joinTableSource;
+    } else {
+      return originalSource;
+    }
+  }
+  
+  /**
+   * May consolidate a single filter with `child`. This is a helper function for simplify2().
+   *
+   * @param originalFilter The original filter
+   * @param child The child node
+   * @param baseTableToRemove The placeholder to be replaced
+   * @return
+   */
+  private static UnnamedColumn consolidateFilter(
+      UnnamedColumn originalFilter, ExecutableNodeBase child, BaseTable baseTableToRemove) {
+    
+    // exception
+    if (!(child instanceof QueryNodeBase)) {
+      return originalFilter;
+    }
+    
+    SelectQuery childSelectQuery = ((QueryNodeBase) child).getSelectQuery();
+  
+    if (originalFilter instanceof ColumnOp) {
+      ColumnOp originalColumnOp = (ColumnOp) originalFilter;
+      List<UnnamedColumn> newOperands = new ArrayList<>();
+      for (UnnamedColumn o : originalColumnOp.getOperands()) {
+        newOperands.add(consolidateFilter(o, child, baseTableToRemove));
+      }
+      ColumnOp newColumnOp = new ColumnOp(originalColumnOp.getOpType(), newOperands);
+      return newColumnOp;
+    } else if (originalFilter instanceof SubqueryColumn) {
+      SubqueryColumn originalSubquery = (SubqueryColumn) originalFilter;
+      SelectQuery subquery = originalSubquery.getSubquery();
+      List<AbstractRelation> subqueryFromList = subquery.getFromList();
+      if (subqueryFromList.size() == 1 && subqueryFromList.get(0).equals(baseTableToRemove)) {
+        originalSubquery.setSubquery(childSelectQuery);
+      }
+      return originalSubquery;
+    }
+    
+    return originalFilter;
+  }
+  
+  @Override
+  public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {
+    
+    return selectQuery;
+  }
+  
+  @Override
+  public ExecutionInfoToken createToken(DbmsQueryResult result) {
+    ExecutionInfoToken token = new ExecutionInfoToken();
+    token.setKeyValue("queryResult", result);
+    return token;
+  }
+
+}

--- a/src/main/java/org/verdictdb/core/sqlobject/CreateSchemaQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateSchemaQuery.java
@@ -14,9 +14,7 @@
  *    limitations under the License.
  */
 
-package org.verdictdb.core.querying;
-
-import org.verdictdb.core.sqlobject.SqlConvertible;
+package org.verdictdb.core.sqlobject;
 
 public class CreateSchemaQuery implements SqlConvertible {
 

--- a/src/main/java/org/verdictdb/core/sqlobject/CreateTableQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateTableQuery.java
@@ -25,6 +25,14 @@ public class CreateTableQuery implements SqlConvertible {
   protected String tableName;
 
   protected boolean ifNotExists = false;
+  
+  public static CreateTableQuery create(String schema, String table) {
+    CreateTableQuery query = new CreateTableQuery();
+    query.schemaName = schema;
+    query.tableName = table;
+    query.ifNotExists = true;
+    return query;
+  }
 
   public String getSchemaName() {
     return schemaName;

--- a/src/main/java/org/verdictdb/core/sqlobject/WithClause.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/WithClause.java
@@ -1,0 +1,32 @@
+package org.verdictdb.core.sqlobject;
+
+public class WithClause implements SqlConvertible {
+  
+  private static final long serialVersionUID = -3295224306523301269L;
+  
+  private String tableName;
+  
+  private SelectQuery selectQuery;
+  
+  public WithClause(String tableName, SelectQuery selectQuery) {
+    this.tableName = tableName;
+    this.selectQuery = selectQuery;
+  }
+
+  public SelectQuery getSelectQuery() {
+    return selectQuery;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setSelectQuery(SelectQuery selectQuery) {
+    this.selectQuery = selectQuery;
+  }
+
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
+  }
+  
+}

--- a/src/main/java/org/verdictdb/jdbc41/Driver.java
+++ b/src/main/java/org/verdictdb/jdbc41/Driver.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.exception.VerdictDBException;
 
 import com.google.common.base.Joiner;
 
@@ -64,7 +64,7 @@ public class Driver implements java.sql.Driver {
         Connection verdictConnection = new org.verdictdb.jdbc41.VerdictConnection(newUrl, info);
         // System.out.println("VerdictConnection has been created: " + verdictConnection);
         return verdictConnection;
-      } catch (VerdictDBDbmsException e) {
+      } catch (VerdictDBException e) {
         e.printStackTrace();
         throw new SQLException(e.getMessage());
       }

--- a/src/main/java/org/verdictdb/jdbc41/VerdictConnection.java
+++ b/src/main/java/org/verdictdb/jdbc41/VerdictConnection.java
@@ -16,17 +16,30 @@
 
 package org.verdictdb.jdbc41;
 
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
 import org.verdictdb.VerdictContext;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.CachedDbmsConnection;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
-
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executor;
+import org.verdictdb.exception.VerdictDBException;
 
 public class VerdictConnection implements java.sql.Connection {
 
@@ -34,25 +47,25 @@ public class VerdictConnection implements java.sql.Connection {
 
   boolean isOpen = false;
 
-  public VerdictConnection(String url) throws VerdictDBDbmsException, SQLException {
+  public VerdictConnection(String url) throws SQLException, VerdictDBException {
     vc = VerdictContext.fromConnectionString(url);
     isOpen = true;
   }
 
   public VerdictConnection(String url, Properties info)
-      throws VerdictDBDbmsException, SQLException {
+      throws SQLException, VerdictDBException {
     vc = VerdictContext.fromConnectionString(url, info);
     isOpen = true;
   }
 
   public VerdictConnection(String url, String user, String password)
-      throws VerdictDBDbmsException, SQLException {
+      throws SQLException, VerdictDBException {
     vc = VerdictContext.fromConnectionString(url, user, password);
     isOpen = true;
   }
 
   public VerdictConnection(String url, String user, String password, VerdictOption options)
-      throws VerdictDBDbmsException, SQLException {
+      throws SQLException, VerdictDBException {
     vc = VerdictContext.fromConnectionString(url, user, password, options);
     isOpen = true;
   }

--- a/src/main/java/org/verdictdb/metastore/CachedScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/CachedScrambleMetaStore.java
@@ -1,0 +1,28 @@
+package org.verdictdb.metastore;
+
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+
+public class CachedScrambleMetaStore extends VerdictMetaStore {
+  
+  VerdictMetaStore originalMetaStore;
+  
+  ScrambleMetaSet cachedMetaSet = null;
+  
+  public CachedScrambleMetaStore(VerdictMetaStore metaStore) {
+    this.originalMetaStore = metaStore;
+  }
+  
+  @Override
+  public ScrambleMetaSet retrieve() {
+    if (cachedMetaSet == null) {
+      refreshCache();
+    }
+    
+    return cachedMetaSet;
+  }
+  
+  public void refreshCache() {
+    cachedMetaSet = originalMetaStore.retrieve();
+  }
+
+}

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -16,24 +16,31 @@
 
 package org.verdictdb.metastore;
 
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.DbmsQueryResult;
-import org.verdictdb.core.querying.CreateSchemaQuery;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
-import org.verdictdb.core.sqlobject.*;
+import org.verdictdb.core.sqlobject.BaseColumn;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.CreateSchemaQuery;
+import org.verdictdb.core.sqlobject.CreateTableDefinitionQuery;
+import org.verdictdb.core.sqlobject.DropTableQuery;
+import org.verdictdb.core.sqlobject.InsertValuesQuery;
+import org.verdictdb.core.sqlobject.OrderbyAttribute;
+import org.verdictdb.core.sqlobject.SelectItem;
+import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.ImpalaSyntax;
 import org.verdictdb.sqlsyntax.RedshiftSyntax;
 import org.verdictdb.sqlwriter.QueryToSql;
-
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
 
 public class ScrambleMetaStore extends VerdictMetaStore {
 

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -215,6 +215,7 @@ public class ScrambleMetaStore extends VerdictMetaStore {
    *
    * @return a set of scramble meta
    */
+  @Override
   public ScrambleMetaSet retrieve() {
     ScrambleMetaSet retrieved = new ScrambleMetaSet();
 

--- a/src/main/java/org/verdictdb/metastore/VerdictMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/VerdictMetaStore.java
@@ -16,11 +16,16 @@
 
 package org.verdictdb.metastore;
 
-public class VerdictMetaStore {
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+
+public abstract class VerdictMetaStore {
 
   protected static final String METASTORE_TABLE_NAME = "verdictdbmeta";
 
   public String getMetaStoreTableName() {
     return METASTORE_TABLE_NAME;
   }
+  
+  public abstract ScrambleMetaSet retrieve();
+  
 }

--- a/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
+++ b/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
@@ -29,10 +29,13 @@ import org.verdictdb.metastore.ScrambleMetaStore;
 
 /** Created by Dong Young Yoon on 7/31/18. */
 public class ScrambleTableReplacer {
-  private ScrambleMetaStore store;
+  
+//  private ScrambleMetaStore store;
+  
+  private ScrambleMetaSet metaSet;
 
-  public ScrambleTableReplacer(ScrambleMetaStore store) {
-    this.store = store;
+  public ScrambleTableReplacer(ScrambleMetaSet metaSet) {
+    this.metaSet = metaSet;
   }
 
   public void replace(SelectQuery query) {
@@ -46,20 +49,21 @@ public class ScrambleTableReplacer {
     if (table instanceof BaseTable) {
       BaseTable bt = (BaseTable) table;
       // replace original table with its scrambled table if exists.
-      if (store != null) {
-        ScrambleMetaSet metaSet = store.retrieve();
-        Iterator<ScrambleMeta> iterator = metaSet.iterator();
-        while (iterator.hasNext()) {
-          ScrambleMeta meta = iterator.next();
-          // substitute names with those of the first scrambled table found.
-          if (meta.getOriginalSchemaName().equals(bt.getSchemaName())
-              && meta.getOriginalTableName().equals(bt.getTableName())) {
-            bt.setSchemaName(meta.getSchemaName());
-            bt.setTableName(meta.getTableName());
-            break;
-          }
+//      if (store != null) {
+//      ScrambleMetaSet metaSet = store.retrieve();
+      Iterator<ScrambleMeta> iterator = metaSet.iterator();
+      while (iterator.hasNext()) {
+        ScrambleMeta meta = iterator.next();
+        
+        // substitute names with those of the first scrambled table found.
+        if (meta.getOriginalSchemaName().equals(bt.getSchemaName())
+            && meta.getOriginalTableName().equals(bt.getTableName())) {
+          bt.setSchemaName(meta.getSchemaName());
+          bt.setTableName(meta.getTableName());
+          break;
         }
       }
+//      }
     } else if (table instanceof JoinTable) {
       JoinTable jt = (JoinTable) table;
       for (AbstractRelation relation : jt.getJoinList()) {

--- a/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
+++ b/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
@@ -19,6 +19,7 @@ package org.verdictdb.sqlreader;
 import java.util.Iterator;
 import java.util.List;
 
+import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.sqlobject.AbstractRelation;
@@ -33,6 +34,8 @@ public class ScrambleTableReplacer {
 //  private ScrambleMetaStore store;
   
   private ScrambleMetaSet metaSet;
+  
+  private VerdictDBLogger log = VerdictDBLogger.getLogger(this.getClass());
 
   public ScrambleTableReplacer(ScrambleMetaSet metaSet) {
     this.metaSet = metaSet;
@@ -60,6 +63,11 @@ public class ScrambleTableReplacer {
             && meta.getOriginalTableName().equals(bt.getTableName())) {
           bt.setSchemaName(meta.getSchemaName());
           bt.setTableName(meta.getTableName());
+          
+          log.info(String.format("Automatic table replacement: %s.%s -> %s.%s",
+              meta.getOriginalSchemaName(), meta.getOriginalTableName(), 
+              meta.getSchemaName(), meta.getTableName()));
+          
           break;
         }
       }

--- a/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
+++ b/src/main/java/org/verdictdb/sqlreader/ScrambleTableReplacer.java
@@ -26,7 +26,6 @@ import org.verdictdb.core.sqlobject.AbstractRelation;
 import org.verdictdb.core.sqlobject.BaseTable;
 import org.verdictdb.core.sqlobject.JoinTable;
 import org.verdictdb.core.sqlobject.SelectQuery;
-import org.verdictdb.metastore.ScrambleMetaStore;
 
 /** Created by Dong Young Yoon on 7/31/18. */
 public class ScrambleTableReplacer {

--- a/src/main/java/org/verdictdb/sqlwriter/CreateSchemaToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/CreateSchemaToSql.java
@@ -16,7 +16,7 @@
 
 package org.verdictdb.sqlwriter;
 
-import org.verdictdb.core.querying.CreateSchemaQuery;
+import org.verdictdb.core.sqlobject.CreateSchemaQuery;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 

--- a/src/main/java/org/verdictdb/sqlwriter/QueryToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/QueryToSql.java
@@ -16,7 +16,7 @@
 
 package org.verdictdb.sqlwriter;
 
-import org.verdictdb.core.querying.CreateSchemaQuery;
+import org.verdictdb.core.sqlobject.CreateSchemaQuery;
 import org.verdictdb.core.sqlobject.CreateTableQuery;
 import org.verdictdb.core.sqlobject.DropTableQuery;
 import org.verdictdb.core.sqlobject.InsertValuesQuery;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
+            <level>INFO</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>

--- a/src/test/java/org/verdictdb/VariantMySqlTpchQueryWithoutScramblesTest.java
+++ b/src/test/java/org/verdictdb/VariantMySqlTpchQueryWithoutScramblesTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
@@ -19,14 +26,8 @@ import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlwriter.SelectQueryToSql;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class VariantMySqlTpchQueryWithoutScramblesTest {
 

--- a/src/test/java/org/verdictdb/VerdictContextInitTest.java
+++ b/src/test/java/org/verdictdb/VerdictContextInitTest.java
@@ -16,14 +16,14 @@
 
 package org.verdictdb;
 
-import org.junit.Test;
-import org.verdictdb.commons.VerdictOption;
-import org.verdictdb.exception.VerdictDBDbmsException;
+import static org.junit.Assert.assertEquals;
 
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.verdictdb.commons.VerdictOption;
+import org.verdictdb.exception.VerdictDBException;
 
 /** Created by Dong Young Yoon on 8/9/18. */
 public class VerdictContextInitTest {
@@ -44,7 +44,7 @@ public class VerdictContextInitTest {
   private static final String MYSQL_PASSWORD = "";
 
   @Test
-  public void initFromConnectionStringTest1() throws SQLException, VerdictDBDbmsException {
+  public void initFromConnectionStringTest1() throws SQLException, VerdictDBException {
     String url =
         String.format(
             "jdbc:mysql://%s?autoReconnect=true&useSSL=false&"
@@ -58,7 +58,7 @@ public class VerdictContextInitTest {
   }
 
   @Test
-  public void initFromConnectionStringTest2() throws SQLException, VerdictDBDbmsException {
+  public void initFromConnectionStringTest2() throws SQLException, VerdictDBException {
     String url =
         String.format(
             "jdbc:mysql://%s?autoReconnect=true&useSSL=false&user=root&password=", MYSQL_HOST);

--- a/src/test/java/org/verdictdb/VerdictContextNoAggQueryTest.java
+++ b/src/test/java/org/verdictdb/VerdictContextNoAggQueryTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
@@ -17,14 +24,8 @@ import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlwriter.SelectQueryToSql;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class VerdictContextNoAggQueryTest {
 

--- a/src/test/java/org/verdictdb/commons/VerdictOptionTest.java
+++ b/src/test/java/org/verdictdb/commons/VerdictOptionTest.java
@@ -16,11 +16,11 @@
 
 package org.verdictdb.commons;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 /** Created by Dong Young Yoon on 8/9/18. */
 public class VerdictOptionTest {

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -39,6 +39,7 @@ import org.verdictdb.metastore.ScrambleMetaStore;
 public class CreateScrambleTableFromSqlTest {
 
   private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+//  private static final String[] targetDatabases = {"mysql"};
 
   private static Map<String, Pair<Connection, Connection>> connections = new HashMap<>();
 
@@ -317,7 +318,8 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
+    ScrambleMetaSet scrambleMetaSet = store.retrieve();
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, scrambleMetaSet, options);
     coordinator.process(countOriginalSql);
     SelectQuery query = coordinator.getLastQuery();
 
@@ -353,7 +355,8 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
+    ScrambleMetaSet scrambleMetaSet = store.retrieve();
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, scrambleMetaSet, options);
     coordinator.process(countOriginalSql);
     SelectQuery query = coordinator.getLastQuery();
 

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -34,7 +34,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class CreateScrambleTableFromSqlTest {
 
-  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+//  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+  private static final String[] targetDatabases = {"mysql"};
 
   private static Map<String, Pair<Connection, Connection>> connections = new HashMap<>();
 
@@ -62,9 +63,9 @@ public class CreateScrambleTableFromSqlTest {
   public static void setup() throws VerdictDBDbmsException, SQLException, IOException {
     options.setVerdictTempSchemaName(TEMP_SCHEMA_NAME);
     setupMysql();
-    setupImpala();
-    setupRedshift();
-    setupPostgresql();
+//    setupImpala();
+//    setupRedshift();
+//    setupPostgresql();
   }
 
   @AfterClass
@@ -105,8 +106,8 @@ public class CreateScrambleTableFromSqlTest {
             DatabaseConnectionHelpers.MYSQL_HOST);
     String vcMysqlConnectionString =
         String.format(
-            "jdbc:verdict:mysql://%s?autoReconnect=true&useSSL=false",
-            DatabaseConnectionHelpers.MYSQL_HOST);
+            "jdbc:verdict:mysql://%s?autoReconnect=true&useSSL=false&verdictdbtempschema=%s",
+            DatabaseConnectionHelpers.MYSQL_HOST, TEMP_SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupMySql(
             mysqlConnectionString,
@@ -130,7 +131,8 @@ public class CreateScrambleTableFromSqlTest {
     String connectionString =
         String.format("jdbc:impala://%s", DatabaseConnectionHelpers.IMPALA_HOST);
     String vcConnectionString =
-        String.format("jdbc:verdict:impala://%s", DatabaseConnectionHelpers.IMPALA_HOST);
+        String.format("jdbc:verdict:impala://%s;verdictdbtempschema=%s", 
+            DatabaseConnectionHelpers.IMPALA_HOST, TEMP_SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupImpala(
             connectionString,
@@ -159,8 +161,10 @@ public class CreateScrambleTableFromSqlTest {
             DatabaseConnectionHelpers.REDSHIFT_HOST, DatabaseConnectionHelpers.REDSHIFT_DATABASE);
     String vcConnectionString =
         String.format(
-            "jdbc:verdict:redshift://%s/%s",
-            DatabaseConnectionHelpers.REDSHIFT_HOST, DatabaseConnectionHelpers.REDSHIFT_DATABASE);
+            "jdbc:verdict:redshift://%s/%s?verdictdbtempschema=%s",
+            DatabaseConnectionHelpers.REDSHIFT_HOST, 
+            DatabaseConnectionHelpers.REDSHIFT_DATABASE,
+            TEMP_SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupRedshift(
             connectionString,
@@ -189,8 +193,10 @@ public class CreateScrambleTableFromSqlTest {
             DatabaseConnectionHelpers.POSTGRES_HOST, DatabaseConnectionHelpers.POSTGRES_DATABASE);
     String vcConnectionString =
         String.format(
-            "jdbc:verdict:postgresql://%s/%s",
-            DatabaseConnectionHelpers.POSTGRES_HOST, DatabaseConnectionHelpers.POSTGRES_DATABASE);
+            "jdbc:verdict:postgresql://%s/%s?verdictdbtempschema=%s",
+            DatabaseConnectionHelpers.POSTGRES_HOST, 
+            DatabaseConnectionHelpers.POSTGRES_DATABASE,
+            TEMP_SCHEMA_NAME);
     Connection conn =
         DatabaseConnectionHelpers.setupPostgresql(
             connectionString,
@@ -308,7 +314,7 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
     coordinator.process(countOriginalSql);
     SelectQuery query = coordinator.getLastQuery();
 
@@ -344,7 +350,7 @@ public class CreateScrambleTableFromSqlTest {
         String.format(
             "SELECT * FROM %s.lineitem LIMIT 1", DatabaseConnectionHelpers.COMMON_SCHEMA_NAME);
 
-    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(jdbcConn, options);
     coordinator.process(countOriginalSql);
     SelectQuery query = coordinator.getLastQuery();
 

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -1,5 +1,19 @@
 package org.verdictdb.coordinator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -19,16 +33,6 @@ import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.metastore.ScrambleMetaStore;
-
-import java.io.IOException;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /** Created by Dong Young Yoon on 7/26/18. */
 @RunWith(Parameterized.class)

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -34,8 +34,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class CreateScrambleTableFromSqlTest {
 
-//  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
-  private static final String[] targetDatabases = {"mysql"};
+  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
 
   private static Map<String, Pair<Connection, Connection>> connections = new HashMap<>();
 
@@ -63,9 +62,9 @@ public class CreateScrambleTableFromSqlTest {
   public static void setup() throws VerdictDBDbmsException, SQLException, IOException {
     options.setVerdictTempSchemaName(TEMP_SCHEMA_NAME);
     setupMysql();
-//    setupImpala();
-//    setupRedshift();
-//    setupPostgresql();
+    setupImpala();
+    setupRedshift();
+    setupPostgresql();
   }
 
   @AfterClass

--- a/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
@@ -100,7 +100,7 @@ public class ExecutionContextTest {
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
     VerdictContext verdict = new VerdictContext(dbmsConn);
     ExecutionContext exec = new ExecutionContext(
-        dbmsConn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsConn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
 
     VerdictSingleResult result = exec.sql(sql);
   }
@@ -116,7 +116,7 @@ public class ExecutionContextTest {
     dbmsConn.setDefaultSchema(MYSQL_DATABASE);
     VerdictContext verdict = new VerdictContext(dbmsConn, options);
     ExecutionContext exec = new ExecutionContext(
-        dbmsConn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsConn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
 
     VerdictResultStream result = exec.streamsql(sql);
 
@@ -147,7 +147,7 @@ public class ExecutionContextTest {
     dbmsConn.setDefaultSchema(MYSQL_DATABASE);
     VerdictContext verdict = new VerdictContext(dbmsConn, options);
     ExecutionContext exec = new ExecutionContext(
-        dbmsConn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsConn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
 
     VerdictResultStream result = exec.streamsql(sql);
 

--- a/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ExecutionContextTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb.coordinator;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -16,14 +23,8 @@ import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.metastore.ScrambleMetaStore;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class ExecutionContextTest {
 

--- a/src/test/java/org/verdictdb/coordinator/ImpalaTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ImpalaTpchSelectQueryCoordinatorTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb.coordinator;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,14 +27,8 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.ImpalaSyntax;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class ImpalaTpchSelectQueryCoordinatorTest {
 

--- a/src/test/java/org/verdictdb/coordinator/ImpalaUniformScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/ImpalaUniformScramblingCoordinatorTest.java
@@ -1,5 +1,13 @@
 package org.verdictdb.coordinator;
 
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -11,14 +19,6 @@ import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class ImpalaUniformScramblingCoordinatorTest {
 

--- a/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
@@ -1,5 +1,21 @@
 package org.verdictdb.coordinator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -13,14 +29,11 @@ import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
-import org.verdictdb.sqlsyntax.*;
-
-import java.io.IOException;
-import java.sql.*;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.verdictdb.sqlsyntax.ImpalaSyntax;
+import org.verdictdb.sqlsyntax.MysqlSyntax;
+import org.verdictdb.sqlsyntax.PostgresqlSyntax;
+import org.verdictdb.sqlsyntax.RedshiftSyntax;
+import org.verdictdb.sqlsyntax.SqlSyntax;
 
 @RunWith(Parameterized.class)
 public class MetaDataStatementsTest {

--- a/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
@@ -275,7 +275,7 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
     ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql("show schemas");
 
     Set<String> expected = new HashSet<>();
@@ -322,7 +322,7 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
     ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
 
     Set<String> expected = new HashSet<>();
@@ -373,7 +373,7 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
     VerdictContext verdict = new VerdictContext(dbmsconn);
     ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getScrambleMetaSet(), verdict.getContextId(), 0, options);
+        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
     while (jdbcRs.next()) {
       result.next();

--- a/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MySqlTpchSelectQueryCoordinatorTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb.coordinator;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,14 +27,8 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 /**
  * Test cases are from

--- a/src/test/java/org/verdictdb/coordinator/PostgreSqlTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/PostgreSqlTpchSelectQueryCoordinatorTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb.coordinator;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,14 +27,8 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class PostgreSqlTpchSelectQueryCoordinatorTest {
 

--- a/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
@@ -1,7 +1,14 @@
 package org.verdictdb.coordinator;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,14 +27,8 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.RedshiftSyntax;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 /**
  * Test cases are from

--- a/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
@@ -1,5 +1,14 @@
 package org.verdictdb.coordinator;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -11,15 +20,6 @@ import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class RedshiftUniformScramblingCoordinatorTest {
 

--- a/src/test/java/org/verdictdb/coordinator/SparkTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/SparkTpchSelectQueryCoordinatorTest.java
@@ -1,5 +1,7 @@
 package org.verdictdb.coordinator;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -23,8 +25,6 @@ import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlwriter.SelectQueryToSql;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test cases are from

--- a/src/test/java/org/verdictdb/core/querying/TpchAsyncExecutionPlanSimplifierTest.java
+++ b/src/test/java/org/verdictdb/core/querying/TpchAsyncExecutionPlanSimplifierTest.java
@@ -1,5 +1,17 @@
 package org.verdictdb.core.querying;
 
+import static java.sql.Types.BIGINT;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
@@ -12,24 +24,25 @@ import org.verdictdb.core.querying.ola.AsyncQueryExecutionPlan;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.scrambling.UniformScrambler;
-import org.verdictdb.core.sqlobject.*;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.AliasReference;
+import org.verdictdb.core.sqlobject.AliasedColumn;
+import org.verdictdb.core.sqlobject.AsteriskColumn;
+import org.verdictdb.core.sqlobject.BaseColumn;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.ColumnOp;
+import org.verdictdb.core.sqlobject.ConstantColumn;
+import org.verdictdb.core.sqlobject.CreateTableAsSelectQuery;
+import org.verdictdb.core.sqlobject.GroupingAttribute;
+import org.verdictdb.core.sqlobject.JoinTable;
+import org.verdictdb.core.sqlobject.SelectItem;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.H2Syntax;
 import org.verdictdb.sqlwriter.QueryToSql;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
-import static java.sql.Types.BIGINT;
-import static org.junit.Assert.assertEquals;
 
 public class TpchAsyncExecutionPlanSimplifierTest {
 

--- a/src/test/java/org/verdictdb/core/querying/TpchAsyncExecutionPlanTest.java
+++ b/src/test/java/org/verdictdb/core/querying/TpchAsyncExecutionPlanTest.java
@@ -1,5 +1,17 @@
 package org.verdictdb.core.querying;
 
+import static java.sql.Types.BIGINT;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
@@ -12,24 +24,25 @@ import org.verdictdb.core.querying.ola.AsyncQueryExecutionPlan;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.scrambling.UniformScrambler;
-import org.verdictdb.core.sqlobject.*;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.AliasReference;
+import org.verdictdb.core.sqlobject.AliasedColumn;
+import org.verdictdb.core.sqlobject.AsteriskColumn;
+import org.verdictdb.core.sqlobject.BaseColumn;
+import org.verdictdb.core.sqlobject.BaseTable;
+import org.verdictdb.core.sqlobject.ColumnOp;
+import org.verdictdb.core.sqlobject.ConstantColumn;
+import org.verdictdb.core.sqlobject.CreateTableAsSelectQuery;
+import org.verdictdb.core.sqlobject.GroupingAttribute;
+import org.verdictdb.core.sqlobject.JoinTable;
+import org.verdictdb.core.sqlobject.SelectItem;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.H2Syntax;
 import org.verdictdb.sqlwriter.QueryToSql;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
-import static java.sql.Types.BIGINT;
-import static org.junit.Assert.assertEquals;
 
 public class TpchAsyncExecutionPlanTest {
 

--- a/src/test/java/org/verdictdb/jdbc41/DriverTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/DriverTest.java
@@ -1,7 +1,16 @@
 package org.verdictdb.jdbc41;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Properties;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -9,12 +18,8 @@ import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.exception.VerdictDBDbmsException;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.*;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 public class DriverTest {
 

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -1,5 +1,19 @@
 package org.verdictdb.jdbc41;
 
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -7,12 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.verdictdb.commons.VerdictOption;
-import org.verdictdb.exception.VerdictDBDbmsException;
-
-import java.sql.*;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
+import org.verdictdb.exception.VerdictDBException;
 
 /** Created by Dong Young Yoon on 7/18/18. */
 @RunWith(Parameterized.class)
@@ -102,7 +111,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
   }
 
   @BeforeClass
-  public static void setupDatabases() throws SQLException, VerdictDBDbmsException {
+  public static void setupDatabases() throws SQLException, VerdictDBException {
     setupMysql();
     setupImpala();
     setupRedshift();
@@ -202,7 +211,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     }
   }
 
-  private static Connection setupMysql() throws SQLException, VerdictDBDbmsException {
+  private static Connection setupMysql() throws SQLException, VerdictDBException {
     String mysqlConnectionString =
         String.format("jdbc:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
     Connection conn =
@@ -218,7 +227,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     return conn;
   }
 
-  private static Connection setupImpala() throws SQLException, VerdictDBDbmsException {
+  private static Connection setupImpala() throws SQLException, VerdictDBException {
     String connectionString = String.format("jdbc:impala://%s", IMPALA_HOST);
     Connection conn = DriverManager.getConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD);
     VerdictConnection vc = new VerdictConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD);
@@ -232,7 +241,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     return conn;
   }
 
-  public static Connection setupRedshift() throws SQLException, VerdictDBDbmsException {
+  public static Connection setupRedshift() throws SQLException, VerdictDBException {
     String connectionString =
         String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
     Connection conn =
@@ -249,7 +258,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     return conn;
   }
 
-  public static Connection setupPostgresql() throws SQLException, VerdictDBDbmsException {
+  public static Connection setupPostgresql() throws SQLException, VerdictDBException {
     String connectionString =
         String.format("jdbc:postgresql://%s/%s", POSTGRES_HOST, POSTGRES_DATABASE);
     Connection conn =

--- a/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
@@ -1,5 +1,19 @@
 package org.verdictdb.jdbc41;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -9,16 +23,7 @@ import org.junit.runners.Parameterized;
 import org.postgresql.jdbc.PgSQLXML;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
-import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 /** Created by Dong Young Yoon on 7/18/18. */
 @RunWith(Parameterized.class)
@@ -115,7 +120,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
       "data_type_test" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   @BeforeClass
-  public static void setup() throws SQLException, VerdictDBDbmsException {
+  public static void setup() throws SQLException, VerdictDBException {
     options.setVerdictMetaSchemaName(VERDICT_META_SCHEMA);
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
@@ -142,7 +147,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
     return params;
   }
 
-  private static void setupMysql() throws SQLException, VerdictDBDbmsException {
+  private static void setupMysql() throws SQLException, VerdictDBException {
     String mysqlConnectionString =
         String.format("jdbc:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
     String vcMysqlConnectionString =
@@ -173,7 +178,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
     conn.close();
   }
 
-  private static void setupImpala() throws SQLException, VerdictDBDbmsException {
+  private static void setupImpala() throws SQLException, VerdictDBException {
     String connectionString = String.format("jdbc:impala://%s", IMPALA_HOST);
     Connection conn =
         DatabaseConnectionHelpers.setupImpalaForDataTypeTest(
@@ -202,7 +207,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
     conn.close();
   }
 
-  private static void setupRedshift() throws SQLException, VerdictDBDbmsException {
+  private static void setupRedshift() throws SQLException, VerdictDBException {
     String connectionString =
         String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
     Connection conn =
@@ -232,7 +237,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
     conn.close();
   }
 
-  private static void setupPostgresql() throws SQLException, VerdictDBDbmsException {
+  private static void setupPostgresql() throws SQLException, VerdictDBException {
     String connectionString =
         String.format("jdbc:postgresql://%s/%s", POSTGRES_HOST, POSTGRES_DATABASE);
     Connection conn =

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -54,7 +54,7 @@ public class JdbcTpchQueryForAllDatabasesTest {
   // TODO: Add support for all four databases
   //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
   private static final String[] targetDatabases = {"mysql", "impala", "redshift"};
-  //  private static final String[] targetDatabases = { "impala" };
+//    private static final String[] targetDatabases = { "mysql" };
 
   public JdbcTpchQueryForAllDatabasesTest(String database, String query) {
     this.database = database;

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -1,7 +1,20 @@
 package org.verdictdb.jdbc41;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -11,17 +24,10 @@ import org.junit.runners.Parameterized;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.exception.VerdictDBException;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 /** Created by Dong Young Yoon on 7/18/18. */
 @RunWith(Parameterized.class)
@@ -238,7 +244,7 @@ public class JdbcTpchQueryForAllDatabasesTest {
   }
 
   public static Connection setupPostgresql()
-      throws SQLException, VerdictDBDbmsException, IOException {
+      throws SQLException, IOException, VerdictDBException {
     String connectionString =
         String.format("jdbc:postgresql://%s/%s", POSTGRES_HOST, POSTGRES_DATABASE);
     Connection conn =

--- a/src/test/java/org/verdictdb/metastore/ScrambleMetaStoreTest.java
+++ b/src/test/java/org/verdictdb/metastore/ScrambleMetaStoreTest.java
@@ -1,5 +1,15 @@
 package org.verdictdb.metastore;
 
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -13,16 +23,6 @@ import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 public class ScrambleMetaStoreTest {
 

--- a/src/test/java/org/verdictdb/sqlreader/MySqlSqlToRelationFailureTest.java
+++ b/src/test/java/org/verdictdb/sqlreader/MySqlSqlToRelationFailureTest.java
@@ -1,5 +1,12 @@
 package org.verdictdb.sqlreader;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
@@ -13,13 +20,6 @@ import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class MySqlSqlToRelationFailureTest {
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
     </appender>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
+            <level>DEBUG</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
     </appender>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
+            <level>INFO</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>


### PR DESCRIPTION
1. Simplifier logic has been enabled.
2. ScrambleMetaSet is retrieved only once when VerdictContext is created.