### PR TITLE
Apply random schema names whenever VerdictOption is used

### DIFF
--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -26,6 +26,11 @@ public class JdbcCommonQueryForAllDatabasesTest {
 
   private static VerdictOption options = new VerdictOption();
 
+  private static final String VERDICT_META_SCHEMA =
+      "verdictdbmetaschema_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
+  private static final String VERDICT_TEMP_SCHEMA =
+      "verdictdbtempschema_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
+
   private static final String MYSQL_HOST;
 
   private String database = "";
@@ -103,6 +108,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
 
   @BeforeClass
   public static void setupDatabases() throws SQLException, VerdictDBDbmsException {
+    options.setVerdictMetaSchemaName(VERDICT_META_SCHEMA);
+    options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupImpala();
     setupRedshift();

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -214,7 +214,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
         String.format("jdbc:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
     Connection conn =
         DriverManager.getConnection(mysqlConnectionString, MYSQL_USER, MYSQL_PASSWORD);
-    VerdictConnection vc = new VerdictConnection(mysqlConnectionString, MYSQL_USER, MYSQL_PASSWORD);
+    VerdictConnection vc =
+        new VerdictConnection(mysqlConnectionString, MYSQL_USER, MYSQL_PASSWORD, options);
     loadData(conn);
     connMap.put("mysql", conn);
     vcMap.put("mysql", vc);
@@ -228,7 +229,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
   private static Connection setupImpala() throws SQLException, VerdictDBDbmsException {
     String connectionString = String.format("jdbc:impala://%s", IMPALA_HOST);
     Connection conn = DriverManager.getConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD);
-    VerdictConnection vc = new VerdictConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD);
+    VerdictConnection vc =
+        new VerdictConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD, options);
     loadDataImpala(conn);
     connMap.put("impala", conn);
     vcMap.put("impala", vc);
@@ -245,7 +247,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     Connection conn =
         DriverManager.getConnection(connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD);
     VerdictConnection vc =
-        new VerdictConnection(connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD);
+        new VerdictConnection(connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD, options);
     loadData(conn);
     connMap.put("redshift", conn);
     vcMap.put("redshift", vc);
@@ -262,7 +264,7 @@ public class JdbcCommonQueryForAllDatabasesTest {
     Connection conn =
         DriverManager.getConnection(connectionString, POSTGRES_USER, POSTGRES_PASSWORD);
     VerdictConnection vc =
-        new VerdictConnection(connectionString, POSTGRES_USER, POSTGRES_PASSWORD);
+        new VerdictConnection(connectionString, POSTGRES_USER, POSTGRES_PASSWORD, options);
     loadData(conn);
     connMap.put("postgresql", conn);
     vcMap.put("postgresql", vc);

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -41,6 +41,11 @@ public class JdbcTpchQueryForAllDatabasesTest {
 
   private static final int TPCH_QUERY_COUNT = 22;
 
+  private static final String VERDICT_META_SCHEMA =
+      "verdictdbmetaschema_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
+  private static final String VERDICT_TEMP_SCHEMA =
+      "verdictdbtempschema_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
+
   private String database = "";
 
   private String query;
@@ -123,6 +128,8 @@ public class JdbcTpchQueryForAllDatabasesTest {
 
   @BeforeClass
   public static void setupDatabases() throws SQLException, VerdictDBDbmsException, IOException {
+    options.setVerdictMetaSchemaName(VERDICT_META_SCHEMA);
+    options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupImpala();
     setupRedshift();

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -189,7 +189,9 @@ public class JdbcTpchQueryForAllDatabasesTest {
     String mysqlConnectionString =
         String.format("jdbc:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
     String vcMysqlConnectionString =
-        String.format("jdbc:verdict:mysql://%s?autoReconnect=true&useSSL=false", MYSQL_HOST);
+        String.format(
+            "jdbc:verdict:mysql://%s?autoReconnect=true&useSSL=false&verdictdbmetaschema=%s&verdictdbtempschema=%s",
+            MYSQL_HOST, VERDICT_META_SCHEMA, VERDICT_TEMP_SCHEMA);
     Connection conn =
         DatabaseConnectionHelpers.setupMySql(
             mysqlConnectionString, MYSQL_USER, MYSQL_PASSWORD, SCHEMA_NAME);
@@ -209,7 +211,10 @@ public class JdbcTpchQueryForAllDatabasesTest {
 
   private static Connection setupImpala() throws SQLException, VerdictDBDbmsException {
     String connectionString = String.format("jdbc:impala://%s", IMPALA_HOST);
-    String verdictConnectionString = String.format("jdbc:verdict:impala://%s", IMPALA_HOST);
+    String verdictConnectionString =
+        String.format(
+            "jdbc:verdict:impala://%s;verdictdbmetaschema=%s;verdictdbtempschema=%s", IMPALA_HOST,
+            VERDICT_META_SCHEMA, VERDICT_TEMP_SCHEMA);
     Connection conn =
         DatabaseConnectionHelpers.setupImpala(
             connectionString, IMPALA_USER, IMPALA_PASSWORD, SCHEMA_NAME);
@@ -229,7 +234,8 @@ public class JdbcTpchQueryForAllDatabasesTest {
     String connectionString =
         String.format("jdbc:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
     String verdictConnectionString =
-        String.format("jdbc:verdict:redshift://%s/%s", REDSHIFT_HOST, REDSHIFT_DATABASE);
+        String.format("jdbc:verdict:redshift://%s/%s;verdictdbmetaschema=%s;verdictdbtempschema=%s",
+            REDSHIFT_HOST, REDSHIFT_DATABASE, VERDICT_META_SCHEMA, VERDICT_TEMP_SCHEMA);
     Connection conn =
         DatabaseConnectionHelpers.setupRedshift(
             connectionString, REDSHIFT_USER, REDSHIFT_PASSWORD, SCHEMA_NAME);
@@ -252,7 +258,7 @@ public class JdbcTpchQueryForAllDatabasesTest {
         DatabaseConnectionHelpers.setupPostgresql(
             connectionString, POSTGRES_HOST, POSTGRES_PASSWORD, SCHEMA_NAME);
     VerdictConnection vc =
-        new VerdictConnection(connectionString, POSTGRES_USER, POSTGRES_PASSWORD);
+        new VerdictConnection(connectionString, POSTGRES_USER, POSTGRES_PASSWORD, options);
     connMap.put("postgresql", conn);
     vcMap.put("postgresql", vc);
     schemaMap.put("postgresql", "");


### PR DESCRIPTION
This is follow up for #204 as I found a few unit tests that needed to have randomized schema names and options that need to be applied correctly. 