### PR TITLE
"loglevel" and "file_loglevel" options change the log levels for console and file logs

### DIFF
--- a/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
+++ b/src/main/java/org/verdictdb/commons/VerdictDBLogger.java
@@ -18,14 +18,21 @@ package org.verdictdb.commons;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.FileAppender;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+
+import java.util.Iterator;
 
 public class VerdictDBLogger implements org.slf4j.Logger {
 
   private org.slf4j.Logger logger;
+
+  private static final String VERDICT_LOGGER_NAME = "org.verdictdb";
 
   private VerdictDBLogger(org.slf4j.Logger logger) {
     this.logger = logger;
@@ -37,6 +44,39 @@ public class VerdictDBLogger implements org.slf4j.Logger {
 
   public static VerdictDBLogger getLogger(String name) {
     return new VerdictDBLogger(LoggerFactory.getLogger(name));
+  }
+
+  public static void setConsoleLogLevel(String level) {
+    ThresholdFilter thresholdFilter = new ThresholdFilter();
+    thresholdFilter.setLevel(level);
+    Logger root = (Logger) LoggerFactory.getLogger(VERDICT_LOGGER_NAME);
+    Iterator<Appender<ILoggingEvent>> iterator = root.iteratorForAppenders();
+    while (iterator.hasNext()) {
+      Appender<ILoggingEvent> appender = iterator.next();
+      if (appender instanceof ConsoleAppender) {
+        ConsoleAppender ca = (ConsoleAppender) appender;
+        ca.clearAllFilters();
+        ca.addFilter(thresholdFilter);
+        thresholdFilter.start();
+      }
+    }
+  }
+
+  public static void setFileLogLevel(String level) {
+    ThresholdFilter thresholdFilter = new ThresholdFilter();
+    thresholdFilter.setLevel(level);
+    // For file log, we need to change root logger's appender.
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    Iterator<Appender<ILoggingEvent>> iterator = root.iteratorForAppenders();
+    while (iterator.hasNext()) {
+      Appender<ILoggingEvent> appender = iterator.next();
+      if (appender instanceof FileAppender) {
+        FileAppender fa = (FileAppender) appender;
+        fa.clearAllFilters();
+        fa.addFilter(thresholdFilter);
+        thresholdFilter.start();
+      }
+    }
   }
 
   public void setLevel(Level level) {

--- a/src/main/java/org/verdictdb/commons/VerdictOption.java
+++ b/src/main/java/org/verdictdb/commons/VerdictOption.java
@@ -29,8 +29,13 @@ public class VerdictOption {
   private static final String DEFAULT_META_SCHEMA_NAME = "verdictdbmeta";
   private static final String DEFAULT_TEMP_SCHEMA_NAME = "verdictdbtemp";
 
+  private static final String DEFAULT_CONSOLE_LOG_LEVEL = "info";
+  private static final String DEFAULT_FILE_LOG_LEVEL = "debug";
+
   private String verdictMetaSchemaName = DEFAULT_META_SCHEMA_NAME;
   private String verdictTempSchemaName = DEFAULT_TEMP_SCHEMA_NAME;
+  private String verdictConsoleLogLevel = DEFAULT_CONSOLE_LOG_LEVEL;
+  private String verdictFileLogLevel = DEFAULT_FILE_LOG_LEVEL;
 
   public VerdictOption() {}
 
@@ -55,6 +60,24 @@ public class VerdictOption {
     return verdictTempSchemaName;
   }
 
+  public String getVerdictConsoleLogLevel() {
+    return verdictConsoleLogLevel;
+  }
+
+  public void setVerdictConsoleLogLevel(String level) {
+    this.verdictConsoleLogLevel = level;
+    VerdictDBLogger.setConsoleLogLevel(level);
+  }
+
+  public String getVerdictFileLogLevel() {
+    return verdictFileLogLevel;
+  }
+
+  public void setVerdictFileLogLevel(String level) {
+    this.verdictFileLogLevel = level;
+    VerdictDBLogger.setFileLogLevel(level);
+  }
+
   public void setVerdictTempSchemaName(String verdictTempSchemaName) {
     this.verdictTempSchemaName = verdictTempSchemaName;
   }
@@ -71,6 +94,14 @@ public class VerdictOption {
     return DEFAULT_TEMP_SCHEMA_NAME;
   }
 
+  public static String getDefaultConsoleLogLevel() {
+    return DEFAULT_CONSOLE_LOG_LEVEL;
+  }
+
+  public static String getDefaultFileLogLevel() {
+    return DEFAULT_FILE_LOG_LEVEL;
+  }
+
   public void parseConnectionString(String str) {
     String[] tokens = str.split("[&;?]");
     String pattern = "\\w+=\\w+";
@@ -81,10 +112,16 @@ public class VerdictOption {
         String[] option = token.split("=");
         switch (option[0].toLowerCase()) {
           case "verdictdbmetaschema":
-            verdictMetaSchemaName = option[1];
+            this.setVerdictMetaSchemaName(option[1]);
             break;
           case "verdictdbtempschema":
-            verdictTempSchemaName = option[1];
+            this.setVerdictTempSchemaName(option[1]);
+            break;
+          case "loglevel":
+            this.setVerdictConsoleLogLevel(option[1]);
+            break;
+          case "file_loglevel":
+            this.setVerdictFileLogLevel(option[1]);
             break;
           default:
             break;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,23 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="ROOT_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>return logger.startsWith("org.verdictdb");</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
+    </appender>
+
+    <appender name="VERDICTDB_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
@@ -24,10 +40,13 @@
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
         </layout>
     </appender>
+
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <logger name="org.verdictdb" level="debug"/>
+    <logger name="org.verdictdb" level="debug">
+        <appender-ref ref="VERDICTDB_STDOUT"/>
+    </logger>
     <root level="warn">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROOT_STDOUT"/>
         <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/src/test/java/org/verdictdb/commons/VerdictDBLoggerTest.java
+++ b/src/test/java/org/verdictdb/commons/VerdictDBLoggerTest.java
@@ -1,23 +1,65 @@
 package org.verdictdb.commons;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
-import org.junit.Test;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import org.junit.Test;
 
-/**
- * Created by Dong Young Yoon on 7/25/18.
- */
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/** Created by Dong Young Yoon on 7/25/18. */
 public class VerdictDBLoggerTest {
 
   @Test
   public void loggerTest() {
     final VerdictDBLogger logger = VerdictDBLogger.getLogger(this.getClass());
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    VerdictOption options = new VerdictOption();
+    options.setVerdictConsoleLogLevel("all");
+    options.setVerdictFileLogLevel("all");
+    appender.setName("testAppender");
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.TRACE);
+    logger.debug("debug test");
+    logger.error("error test");
+    logger.info("info test");
+    logger.trace("trace test");
+    logger.warn("warn test");
+
+    List<ILoggingEvent> events = appender.list;
+
+    assertEquals(Level.DEBUG, events.get(0).getLevel());
+    assertEquals("debug test", events.get(0).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(0).getLoggerName());
+
+    assertEquals(Level.ERROR, events.get(1).getLevel());
+    assertEquals("error test", events.get(1).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(1).getLoggerName());
+
+    assertEquals(Level.INFO, events.get(2).getLevel());
+    assertEquals("info test", events.get(2).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(2).getLoggerName());
+
+    assertEquals(Level.TRACE, events.get(3).getLevel());
+    assertEquals("trace test", events.get(3).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(3).getLoggerName());
+
+    assertEquals(Level.WARN, events.get(4).getLevel());
+    assertEquals("warn test", events.get(4).getMessage());
+    assertEquals("org.verdictdb.commons.VerdictDBLoggerTest", events.get(4).getLoggerName());
+
+    appender.stop();
+  }
+
+  @Test
+  public void loggerOptionTest() {
+    final VerdictDBLogger logger = VerdictDBLogger.getLogger(this.getClass());
+    VerdictOption options = new VerdictOption();
+    options.setVerdictConsoleLogLevel("warn");
+    options.setVerdictFileLogLevel("warn");
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.setName("testAppender");
     appender.start();

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,7 +8,23 @@
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
         </encoder>
     </appender>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="ROOT_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>return logger.startsWith("org.verdictdb");</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
+    </appender>
+
+    <appender name="VERDICTDB_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
@@ -16,11 +32,14 @@
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
         </layout>
     </appender>
+
     <!--<statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />-->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <logger name="org.verdictdb" level="debug"/>
+    <logger name="org.verdictdb" level="debug">
+        <appender-ref ref="VERDICTDB_STDOUT"/>
+    </logger>
     <root level="ERROR">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROOT_STDOUT"/>
         <appender-ref ref="DEBUG"/>
     </root>
 </configuration>


### PR DESCRIPTION
(Related to #210)

Setting 'loglevel' and 'file_loglevel' in VerdictOption changes console and file log levels respectively.

One caveat here is that while it was possible to separate logs from VerdictDB and other libraries for console logs, I could not separate them for file logs as it does not seem to work as intended when we have two appenders for the same log file. So here is how it works for now:

1. For console logs, the changed log level only applies to logs generated by VerdictDB while fixing the log level ('warn' by default in production logback config) in other libraries included
2. For file logs, the changed log level applies to all logs generated by VerdictDB and other libraries as it has to change the log level of root logger

We can change them to always alter root logger's log level or have a separate log files for logs from VerdictDB and others or keep the current implementation.