### PR TITLE
Make VerdictDB work with SQuirreLSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,10 +187,20 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>2.5.10</version>
+        </dependency>
+        <!--<dependency>-->
+        <!--<groupId>log4j</groupId>-->
+        <!--<artifactId>log4j</artifactId>-->
+        <!--<version>1.2.17</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,6 @@
             <artifactId>opencsv</artifactId>
             <version>4.0</version>
         </dependency>
-
         <!-- test supports -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,9 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
-            <groupId>janino</groupId>
+            <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>2.5.10</version>
+            <version>2.7.8</version>
         </dependency>
         <!--<dependency>-->
         <!--<groupId>log4j</groupId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -196,11 +196,11 @@
             <artifactId>janino</artifactId>
             <version>2.7.8</version>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>log4j</groupId>-->
-        <!--<artifactId>log4j</artifactId>-->
-        <!--<version>1.2.17</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>

--- a/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
@@ -17,6 +17,7 @@
 package org.verdictdb.connection;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntaxList;
@@ -28,8 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.verdictdb.commons.VerdictDBLogger;
-
 /**
  * Maintains a pool of multiple java.sql.Connections to provide concurrent execution of queries to
  * the backend database.
@@ -37,22 +36,23 @@ import org.verdictdb.commons.VerdictDBLogger;
  * @author Yongjoo Park
  */
 public class ConcurrentJdbcConnection extends DbmsConnection {
-  
+
   private static final int CONNECTION_POOL_SIZE = 10;
 
   private List<JdbcConnection> connections = new ArrayList<>();
 
   private int nextConnectionIndex = 0;
-  
+
   private VerdictDBLogger logger = VerdictDBLogger.getLogger(getClass());
-  
+
   public ConcurrentJdbcConnection(List<JdbcConnection> connections) {
     this.connections.addAll(connections);
   }
 
   public ConcurrentJdbcConnection(String url, Properties info, SqlSyntax syntax)
       throws VerdictDBDbmsException {
-    logger.debug(String.format("Creating %d JDBC connections with this url: " + url, CONNECTION_POOL_SIZE));
+    logger.debug(
+        String.format("Creating %d JDBC connections with this url: " + url, CONNECTION_POOL_SIZE));
     for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
       try {
         Connection c;
@@ -132,7 +132,7 @@ public class ConcurrentJdbcConnection extends DbmsConnection {
   public SqlSyntax getSyntax() {
     return getNextConnection().getSyntax();
   }
-  
+
   @Override
   public void abort() {
     for (JdbcConnection c : connections) {


### PR DESCRIPTION
- Added slf4j-api, janino (for logbook's Evaluator) in dependencies
- Scrambler creates new schema if not exists
- getMetadata() in VerdictConnecrtion handles ConcurrentJdbcConnection