### PR TITLE
Change uniform scrambling method

### DIFF
--- a/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
@@ -514,7 +514,7 @@ public class FastConvergeScramblingMethod extends ScramblingMethodBase {
   }
 
   @Override
-  public UnnamedColumn getBlockForTierExpr(int tier, Map<String, Object> metaData) {
+  public UnnamedColumn getBlockExprForTier(int tier, Map<String, Object> metaData) {
     List<Double> cumulProb = getCumulativeProbabilityDistributionForTier(metaData, tier);
     List<Double> condProb = computeConditionalProbabilityDistribution(cumulProb);
     int blockCount = cumulProb.size();

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
@@ -68,4 +68,6 @@ public interface ScramblingMethod {
       String originalSchema, String originalTable, Map<String, Object> metaData);
 
   public String getMainTableAlias();
+
+  public UnnamedColumn getBlockForTierExpr(int tier, Map<String, Object> metaData);
 }

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
@@ -69,5 +69,5 @@ public interface ScramblingMethod {
 
   public String getMainTableAlias();
 
-  public UnnamedColumn getBlockForTierExpr(int tier, Map<String, Object> metaData);
+  public UnnamedColumn getBlockExprForTier(int tier, Map<String, Object> metaData);
 }

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
@@ -179,7 +179,11 @@ public class ScramblingNode extends CreateScrambledTableNode {
     // compose block expression
     UnnamedColumn blockExpr = null;
     List<UnnamedColumn> blockOperands = new ArrayList<>();
+
+
     for (int i = 0; i < tierCount; i++) {
+      UnnamedColumn blockForTierExpr = method.getBlockForTierExpr(i, metaData);
+      /*
       List<Double> cumulProb = method.getCumulativeProbabilityDistributionForTier(metaData, i);
       List<Double> condProb = computeConditionalProbabilityDistribution(cumulProb);
       int blockCount = cumulProb.size();
@@ -191,19 +195,20 @@ public class ScramblingNode extends CreateScrambledTableNode {
         blockForTierOperands.add(ConstantColumn.valueOf(j));
       }
       UnnamedColumn blockForTierExpr;
-      ;
+
       if (blockForTierOperands.size() <= 1) {
         blockForTierExpr = ConstantColumn.valueOf(0);
       } else {
         blockForTierExpr = ColumnOp.casewhen(blockForTierOperands);
       }
-
+      */
       if (i < tierCount - 1) {
         // "when" part in the case-when-else expression
         // for the last tier, we don't need this "when" part
         blockOperands.add(ColumnOp.equal(tierExpr, ConstantColumn.valueOf(i)));
       }
       blockOperands.add(blockForTierExpr);
+
     }
 
     // use a simple (non-nested) case expression when there is only a single tier
@@ -233,7 +238,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
    * @param cumulativeProbabilityDistribution
    * @return
    */
-  List<Double> computeConditionalProbabilityDistribution(
+  static List<Double> computeConditionalProbabilityDistribution(
       List<Double> cumulativeProbabilityDistribution) {
     List<Double> cond = new ArrayList<>();
     int length = cumulativeProbabilityDistribution.size();

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
@@ -182,7 +182,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
 
 
     for (int i = 0; i < tierCount; i++) {
-      UnnamedColumn blockForTierExpr = method.getBlockForTierExpr(i, metaData);
+      UnnamedColumn blockForTierExpr = method.getBlockExprForTier(i, metaData);
       /*
       List<Double> cumulProb = method.getCumulativeProbabilityDistributionForTier(metaData, i);
       List<Double> condProb = computeConditionalProbabilityDistribution(cumulProb);

--- a/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
@@ -29,8 +29,6 @@ import org.verdictdb.core.sqlobject.*;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
 
-import static javassist.CtClass.intType;
-
 public class UniformScramblingMethod extends ScramblingMethodBase {
 
   private final String MAIN_TABLE_SOURCE_ALIAS = "t";
@@ -89,14 +87,14 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
   }
 
   @Override
-  public UnnamedColumn getBlockForTierExpr(int tier, Map<String, Object> metaData) {
+  public UnnamedColumn getBlockExprForTier(int tier, Map<String, Object> metaData) {
     DbmsQueryResult tableSizeResult =
         (DbmsQueryResult) metaData.get(TableSizeCountNode.class.getSimpleName());
     tableSizeResult.next();
     long tableSize = tableSizeResult.getLong(TableSizeCountNode.TOTAL_COUNT_ALIAS_NAME);
     totalNumberOfblocks = (int) Math.ceil(tableSize / (float) blockSize);
     UnnamedColumn blockForTierExpr = ColumnOp.cast(
-        ColumnOp.floor(ColumnOp.multiply(ColumnOp.rand(), ConstantColumn.valueOf(totalNumberOfblocks))), ConstantColumn.valueOf(ConstantColumn.databaseDataType.intType));
+        ColumnOp.floor(ColumnOp.multiply(ColumnOp.rand(), ConstantColumn.valueOf(totalNumberOfblocks))), ConstantColumn.valueOf("int"));
     return blockForTierExpr;
   }
 

--- a/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
@@ -25,16 +25,11 @@ import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.execplan.ExecutionInfoToken;
 import org.verdictdb.core.querying.ExecutableNodeBase;
 import org.verdictdb.core.querying.QueryNodeBase;
-import org.verdictdb.core.sqlobject.AbstractRelation;
-import org.verdictdb.core.sqlobject.AliasedColumn;
-import org.verdictdb.core.sqlobject.BaseTable;
-import org.verdictdb.core.sqlobject.ColumnOp;
-import org.verdictdb.core.sqlobject.SelectItem;
-import org.verdictdb.core.sqlobject.SelectQuery;
-import org.verdictdb.core.sqlobject.SqlConvertible;
-import org.verdictdb.core.sqlobject.UnnamedColumn;
+import org.verdictdb.core.sqlobject.*;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
+
+import static javassist.CtClass.intType;
 
 public class UniformScramblingMethod extends ScramblingMethodBase {
 
@@ -91,6 +86,18 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
   @Override
   public String getMainTableAlias() {
     return MAIN_TABLE_SOURCE_ALIAS;
+  }
+
+  @Override
+  public UnnamedColumn getBlockForTierExpr(int tier, Map<String, Object> metaData) {
+    DbmsQueryResult tableSizeResult =
+        (DbmsQueryResult) metaData.get(TableSizeCountNode.class.getSimpleName());
+    tableSizeResult.next();
+    long tableSize = tableSizeResult.getLong(TableSizeCountNode.TOTAL_COUNT_ALIAS_NAME);
+    totalNumberOfblocks = (int) Math.ceil(tableSize / (float) blockSize);
+    UnnamedColumn blockForTierExpr = ColumnOp.cast(
+        ColumnOp.floor(ColumnOp.multiply(ColumnOp.rand(), ConstantColumn.valueOf(totalNumberOfblocks))), ConstantColumn.valueOf(ConstantColumn.databaseDataType.intType));
+    return blockForTierExpr;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/core/sqlobject/ConstantColumn.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/ConstantColumn.java
@@ -25,8 +25,6 @@ public class ConstantColumn implements UnnamedColumn, SelectItem {
 
   private static final long serialVersionUID = -4530737413387725261L;
 
-  public enum databaseDataType {intType};
-
   Object value;
 
   public void setValue(Object value) {

--- a/src/main/java/org/verdictdb/core/sqlobject/ConstantColumn.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/ConstantColumn.java
@@ -25,6 +25,8 @@ public class ConstantColumn implements UnnamedColumn, SelectItem {
 
   private static final long serialVersionUID = -4530737413387725261L;
 
+  public enum databaseDataType {intType};
+
   Object value;
 
   public void setValue(Object value) {
@@ -48,6 +50,12 @@ public class ConstantColumn implements UnnamedColumn, SelectItem {
   }
 
   public static ConstantColumn valueOf(String value) {
+    ConstantColumn c = new ConstantColumn();
+    c.setValue(value);
+    return c;
+  }
+
+  public static ConstantColumn valueOf(Object value) {
     ConstantColumn c = new ConstantColumn();
     c.setValue(value);
     return c;

--- a/src/main/java/org/verdictdb/sqlwriter/SelectQueryToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/SelectQueryToSql.java
@@ -38,6 +38,7 @@ import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBTypeException;
 import org.verdictdb.exception.VerdictDBValueException;
+import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 
@@ -113,7 +114,15 @@ public class SelectQueryToSql {
         return quoteName(base.getColumnName());
       } else return base.getTableSourceAlias() + "." + quoteName(base.getColumnName());
     } else if (column instanceof ConstantColumn) {
-      return ((ConstantColumn) column).getValue().toString();
+      if (((ConstantColumn) column).getValue() instanceof ConstantColumn.databaseDataType) {
+        if (((ConstantColumn) column).getValue().equals(ConstantColumn.databaseDataType.intType)) {
+          if (syntax instanceof MysqlSyntax) {
+            return "unsigned";
+          }
+          else return "int";
+        }
+      }
+      else return ((ConstantColumn) column).getValue().toString();
     } else if (column instanceof AsteriskColumn) {
       return "*";
     } else if (column instanceof ColumnOp) {

--- a/src/test/java/org/verdictdb/core/scrambling/UniformScramblingNodeTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/UniformScramblingNodeTest.java
@@ -120,9 +120,7 @@ public class UniformScramblingNodeTest {
         + "partition p1 values in (1), "
         + "partition p2 values in (2)) "
         + "select t.`id`, 0 as `tiercolumn`, "
-        + "case when (rand() <= 0.3333333333333333) then 0 "
-        + "when (rand() <= 0.49999999999999994) then 1 "
-        + "when (rand() <= 1.0) then 2 else 2 end as `blockcolumn` "
+        + "cast(floor(rand() * 3) as unsigned) as `blockcolumn` "
         + "from `oldschema`.`oldtable` as t";
     assertEquals(expected, sql);
     mysqlConn.createStatement().execute("drop table if exists newschema.newtable");


### PR DESCRIPTION
I have changed the way uniform scrambling creating BlockForTierExpr. Now it will create blocknum using cast(floor(rand()* n) as int).

Also, I find that for mysql, the way to cast to int is cast(column as unsigned/signed). So, I have slightly changed ConstantColumn class. 