### PR TITLE
More strict node ordering

### DIFF
--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -155,7 +155,7 @@ public class SelectQueryCoordinator implements Coordinator {
     QueryExecutionPlanSimplifier.simplify2(asyncPlan);
     log.debug("Plan simplification done.");
     
-//    log.debug(asyncPlan.getRoot().getStructure());
+    log.debug(asyncPlan.getRoot().getStructure());
 
     // execute the plan
     planRunner = new ExecutablePlanRunner(conn, asyncPlan);

--- a/src/main/java/org/verdictdb/core/execplan/ExecutablePlanRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutablePlanRunner.java
@@ -83,12 +83,16 @@ public class ExecutablePlanRunner {
     }
     
     // Run nodes
+    // The nodes whose dependencies have not been finished will terminate immediately.
+    // The leaf nodes will signal its parents (also called subscribers) to make them run.
+    // The signal will be propagated throughout the tree as the nodes are completed.
     Set<Integer> groupIds = plan.getNodeGroupIDs();
     for (int gid : groupIds) {
       List<ExecutableNode> nodes = plan.getNodesInGroup(gid);
       for (ExecutableNode n : nodes) {
         ExecutableNodeRunner nodeRunner = new ExecutableNodeRunner(conn, n);
         nodeRunner.runOnThread();
+//        nodeRunner.run();
         nodeRunners.add(nodeRunner);
       }
     }

--- a/src/main/java/org/verdictdb/core/querying/ola/AggExecutionNodeBlock.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/AggExecutionNodeBlock.java
@@ -292,8 +292,8 @@ public class AggExecutionNodeBlock {
     List<ExecutableNodeBase> newNodes = new ArrayList<>();
     for (ExecutableNodeBase node : blockNodes) {
       ExecutableNodeBase copied = node.deepcopy();
-      copied.cancelSubscriptionsFromAllSubscribers(); // this subscription information will be
-      // properly reconstructed below.
+      // this subscription information will be properly reconstructed below.
+      copied.cancelSubscriptionsFromAllSubscribers(); 
       newNodes.add(copied);
     }
 
@@ -327,137 +327,22 @@ public class AggExecutionNodeBlock {
     return new AggExecutionNodeBlock(newNodes.get(rootIdx));
   }
 
-  // judge the aggregate column
-  //  public static List<ColumnOp> getAggregateColumn(UnnamedColumn sel) {
-  //    List<SelectItem> itemToCheck = new ArrayList<>();
-  //    itemToCheck.add(sel);
-  //    List<ColumnOp> columnOps = new ArrayList<>();
-  //    while (!itemToCheck.isEmpty()) {
-  //      SelectItem s = itemToCheck.get(0);
-  //      itemToCheck.remove(0);
-  //      if (s instanceof ColumnOp) {
-  //        if (((ColumnOp) s).getOpType().equals("count") || ((ColumnOp)
-  // s).getOpType().equals("sum") || ((ColumnOp) s).getOpType().equals("avg")
-  //            ||((ColumnOp) s).getOpType().equals("max")||((ColumnOp)
-  // s).getOpType().equals("min")) {
-  //          columnOps.add((ColumnOp) s);
-  //        }
-  //        else itemToCheck.addAll(((ColumnOp) s).getOperands());
-  //      }
-  //    }
-  //    return columnOps;
-  //  }
-
-  //  List<SelectItem> rewriteSelectlistWithBasicAgg(SelectQuery query, AggMeta meta) {
-  //    List<SelectItem> selectList = query.getSelectList();
-  //    List<String> aggColumnAlias = new ArrayList<>();
-  //    HashMap<String, String> maxminAlias = new HashMap<>();
-  //    List<SelectItem> newSelectlist = new ArrayList<>();
-  //    meta.setOriginalSelectList(selectList);
-  //    for (SelectItem selectItem : selectList) {
-  //      if (selectItem instanceof AliasedColumn) {
-  //        List<ColumnOp> columnOps = getAggregateColumn(((AliasedColumn) selectItem).getColumn());
-  //        // If it contains agg columns
-  //        if (!columnOps.isEmpty()) {
-  //          meta.getAggColumn().put(selectItem, columnOps);
-  //          for (ColumnOp col:columnOps) {
-  //            if (col.getOpType().equals("avg")) {
-  //              if (!meta.getAggColumnAggAliasPair().containsKey(
-  //                  new ImmutablePair<>("sum", col.getOperand(0)))) {
-  //                ColumnOp col1 = new ColumnOp("sum", col.getOperand(0));
-  //                newSelectlist.add(new AliasedColumn(col1, "agg"+aggColumnIdentiferNum));
-  //                meta.getAggColumnAggAliasPair().put(
-  //                    new ImmutablePair<>("sum", col1.getOperand(0)),
-  // "agg"+aggColumnIdentiferNum);
-  //                aggColumnAlias.add("agg"+aggColumnIdentiferNum++);
-  //              }
-  //              if (!meta.getAggColumnAggAliasPair().containsKey(
-  //                  new ImmutablePair<>("count", (UnnamedColumn) new AsteriskColumn()))) {
-  //                ColumnOp col2 = new ColumnOp("count", new AsteriskColumn());
-  //                newSelectlist.add(new AliasedColumn(col2, "agg"+aggColumnIdentiferNum));
-  //                meta.getAggColumnAggAliasPair().put(
-  //                    new ImmutablePair<>("count", (UnnamedColumn) new AsteriskColumn()),
-  // "agg"+aggColumnIdentiferNum);
-  //                aggColumnAlias.add("agg"+aggColumnIdentiferNum++);
-  //              }
-  //            } else if (col.getOpType().equals("count") || col.getOpType().equals("sum")){
-  //              if (col.getOpType().equals("count") &&
-  // !meta.getAggColumnAggAliasPair().containsKey(
-  //                  new ImmutablePair<>("count", (UnnamedColumn)(new AsteriskColumn())))) {
-  //                ColumnOp col1 = new ColumnOp(col.getOpType());
-  //                newSelectlist.add(new AliasedColumn(col1, "agg"+aggColumnIdentiferNum));
-  //                meta.getAggColumnAggAliasPair().put(
-  //                    new ImmutablePair<>(col.getOpType(), (UnnamedColumn)new AsteriskColumn()),
-  // "agg"+aggColumnIdentiferNum);
-  //                aggColumnAlias.add("agg"+aggColumnIdentiferNum++);
-  //              }
-  //              else if (col.getOpType().equals("sum") &&
-  // !meta.getAggColumnAggAliasPair().containsKey(
-  //                  new ImmutablePair<>(col.getOpType(), col.getOperand(0)))) {
-  //                ColumnOp col1 = new ColumnOp(col.getOpType(), col.getOperand(0));
-  //                newSelectlist.add(new AliasedColumn(col1, "agg"+aggColumnIdentiferNum));
-  //                meta.getAggColumnAggAliasPair().put(
-  //                    new ImmutablePair<>(col.getOpType(), col1.getOperand(0)),
-  // "agg"+aggColumnIdentiferNum);
-  //                aggColumnAlias.add("agg"+aggColumnIdentiferNum++);
-  //              }
-  //            } else if (col.getOpType().equals("max") || col.getOpType().equals("min")) {
-  //              ColumnOp col1 = new ColumnOp(col.getOpType(), col.getOperand(0));
-  //              newSelectlist.add(new AliasedColumn(col1, "agg"+aggColumnIdentiferNum));
-  //              meta.getAggColumnAggAliasPairOfMaxMin().put(
-  //                  new ImmutablePair<>(col.getOpType(), col1.getOperand(0)),
-  // "agg"+aggColumnIdentiferNum);
-  //              maxminAlias.put("agg"+aggColumnIdentiferNum++, col.getOpType());
-  //            }
-  //          }
-  //        }
-  //        else {
-  //          newSelectlist.add(selectItem);
-  //        }
-  //      } else {
-  //        newSelectlist.add(selectItem);
-  //      }
-  //    }
-  //    meta.setAggAlias(aggColumnAlias);
-  //    meta.setMaxminAggAlias(maxminAlias);
-  //    return newSelectlist;
-  //  }
-
-  //  void addTierColumn(SelectQuery query, List<SelectItem> newSelectList, ScrambleMetaSet
-  // scrambleMeta) {
-  //    for (AbstractRelation table : query.getFromList()) {
-  //      if (table instanceof BaseTable) {
-  //        String schemaName = ((BaseTable) table).getSchemaName();
-  //        String tableName = ((BaseTable) table).getTableName();
-  //        if (scrambleMeta.isScrambled(schemaName, tableName) &&
-  //            scrambleMeta.getSingleMeta(schemaName, tableName).getNumberOfTiers()>1) {
-  //          newSelectList.add(new AliasedColumn(
-  //              new BaseColumn(schemaName, tableName, table.getAliasName().get(),
-  // scrambleMeta.getTierColumn(schemaName, tableName)),
-  //              VERDICTDB_TIER_COLUMN_NAME + verdictdbTierIndentiferNum));
-  //          query.addGroupby(new AliasReference(VERDICTDB_TIER_COLUMN_NAME +
-  // verdictdbTierIndentiferNum++));
-  //        }
-  //      }
-  //      else if (table instanceof JoinTable) {
-  //        for (AbstractRelation jointable:((JoinTable) table).getJoinList()) {
-  //          if (jointable instanceof BaseTable) {
-  //            String schemaName = ((BaseTable) jointable).getSchemaName();
-  //            String tableName = ((BaseTable) jointable).getTableName();
-  //            if (scrambleMeta.isScrambled(schemaName, tableName) &&
-  // scrambleMeta.getSingleMeta(schemaName, tableName).getNumberOfTiers()>1) {
-  //              newSelectList.add(new AliasedColumn(
-  //                  new BaseColumn(schemaName, tableName, jointable.getAliasName().get(),
-  // scrambleMeta.getTierColumn(schemaName, tableName)),
-  //                  VERDICTDB_TIER_COLUMN_NAME + verdictdbTierIndentiferNum));
-  //              query.addGroupby(new AliasReference(VERDICTDB_TIER_COLUMN_NAME +
-  // verdictdbTierIndentiferNum++));
-  //            }
-  //          }
-  //        }
-  //      }
-  //    }
-  //    verdictdbTierIndentiferNum = 0;
-  //  }
-
+  public List<ExecutableNodeBase> getLeafNodes() {
+    List<ExecutableNodeBase> leafNodes = new ArrayList<>();
+    for (ExecutableNodeBase node : blockNodes) {
+      List<ExecutableNodeBase> sources = node.getSources();
+      boolean allSourcesExternal = true;
+      for (ExecutableNodeBase source : sources) {
+        if (blockNodes.contains(source)) {
+          allSourcesExternal = false;
+        }
+      }
+      
+      if (allSourcesExternal) {
+        leafNodes.add(node);
+      }
+    }
+    
+    return leafNodes;
+  }
 }

--- a/src/main/java/org/verdictdb/core/querying/ola/AsyncQueryExecutionPlan.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/AsyncQueryExecutionPlan.java
@@ -141,6 +141,7 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
 
     List<ExecutableNodeBase> individualAggNodes = new ArrayList<>();
     List<ExecutableNodeBase> combiners = new ArrayList<>();
+    List<AggExecutionNodeBlock> aggblocks = new ArrayList<>(); 
     //    ScrambleMeta scrambleMeta = idCreator.getScrambleMeta();
 
     // First, plan how to perform block aggregation
@@ -214,6 +215,7 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
       }
 
       individualAggNodes.add(aggroot);
+      aggblocks.add(copy);
     }
 
     // Third, stack combiners
@@ -237,7 +239,7 @@ public class AsyncQueryExecutionPlan extends QueryExecutionPlan {
 
     // Fourth, re-link the subscription relationship for the new AsyncAggNode
     ExecutableNodeBase newRoot =
-        AsyncAggExecutionNode.create(idCreator, individualAggNodes, combiners, scrambleMeta, aggNodeBlock);
+        AsyncAggExecutionNode.create(idCreator, aggblocks, combiners, scrambleMeta, aggNodeBlock);
 
     // Finally remove the old subscription information: old copied node -> still used old node
     for (Pair<ExecutableNodeBase, ExecutableNodeBase> parentToSource : oldSubscriptionInformation) {

--- a/src/main/java/org/verdictdb/core/resulthandler/ExecutionTokenReader.java
+++ b/src/main/java/org/verdictdb/core/resulthandler/ExecutionTokenReader.java
@@ -46,6 +46,7 @@ public class ExecutionTokenReader
   }
 
   public void takeOne() {
+    log.trace("Attempts to take a result.");
     queueBuffer = queue.take();
 
     if (queueBuffer.isFailureToken()) {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
     </appender>
     <appender name="ROOT_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
+            <level>TRACE</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
@@ -35,7 +35,7 @@
 
     <!--<statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />-->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <logger name="org.verdictdb" level="debug">
+    <logger name="org.verdictdb" level="trace">
         <appender-ref ref="VERDICTDB_STDOUT"/>
     </logger>
     <root level="ERROR">


### PR DESCRIPTION
This update is to specifically handle the case when the aggregation includes projections, and when the aggregation is performed in an online aggregation fashion. 

Suppose, A is an aggregation which depends on a projection B. We indicate this by A <- B.

For online aggregation, those operations are broken down into multiple pieces as follows:
1. A1 <- B1
2. A2 <- B2

Previously, B2 ran anyway before completing A1, which caused overhead for first processing A1. This update ensure that B2 runs only after A1 finishes.