### PR TITLE
Joezhong fix null cumulative distribution

### DIFF
--- a/docs/docs/getting_started/install.md
+++ b/docs/docs/getting_started/install.md
@@ -56,10 +56,8 @@ You only need a single jar file. This jar file is compiled with JDK8.
     ```
     to check your java compiler version. The output should look like this
     ```
-    $ java -version
-    openjdk version "1.8.0_171-1-ojdkbuild"
-    OpenJDK Runtime Environment (build 1.8.0_171-1-ojdkbuild-b10)
-    OpenJDK 64-Bit Server VM (build 25.171-b10, mixed mode)
+    $ javac -version
+    javac 1.8.0_171-1-ojdkbuild
     ```
     If not, please install JDK first and then use maven to build the file.
 

--- a/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
@@ -95,6 +95,14 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
     totalNumberOfblocks = (int) Math.ceil(tableSize / (float) blockSize);
     UnnamedColumn blockForTierExpr = ColumnOp.cast(
         ColumnOp.floor(ColumnOp.multiply(ColumnOp.rand(), ConstantColumn.valueOf(totalNumberOfblocks))), ConstantColumn.valueOf("int"));
+
+    // store the cumulative probability
+    List<Double> prob = new ArrayList<>();
+    for (int i = 0; i < totalNumberOfblocks; i++) {
+      prob.add((i + 1) / (double) totalNumberOfblocks);
+    }
+    storeCumulativeProbabilityDistribution(tier, prob);
+
     return blockForTierExpr;
   }
 


### PR DESCRIPTION
Related Issue #236 

The problem is that I have comment out ScramblingMethod.getCumulativeProbabilityDistributionForTier() method in ScramblingNode class. 

However, this method will automatically store the distribution by calling storeCumulativeProbabilityDistribution(). I have copied this part to uniform scrambling's getBlockExprForTier() method. It seems good for fast converge since it will call getCumulativeProbabilityDistributionForTier() in getBlockExprForTier().