### PR TITLE
fix datatype converter Null bug

### DIFF
--- a/src/main/java/org/verdictdb/connection/DataTypeConverter.java
+++ b/src/main/java/org/verdictdb/connection/DataTypeConverter.java
@@ -149,6 +149,7 @@ public class DataTypeConverter {
     stringToIntMap.put("smallserial", INTEGER);
     stringToIntMap.put("serial", INTEGER);
     stringToIntMap.put("bigserial", BIGINT);
+    stringToIntMap.put("bigint unsigned", BIGINT);
     stringToIntMap.put("string", VARCHAR);
     stringToIntMap.put("datetime", TIMESTAMP);
     stringToIntMap.put("timestamp", TIMESTAMP);


### PR DESCRIPTION
Related Issue #236 
I find dataTypeConverter class will pass null value for MySQL because it cannot recognize bigint unsigned type. I have added this type. 