### PR TITLE
 executeQuery() throws an exception if the query is not one of {SELECT, DESCRIBE/SHOW TABLE}

### DIFF
--- a/src/main/java/org/verdictdb/VerdictContext.java
+++ b/src/main/java/org/verdictdb/VerdictContext.java
@@ -16,13 +16,6 @@
 
 package org.verdictdb;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.commons.VerdictOption;
@@ -34,13 +27,19 @@ import org.verdictdb.connection.SparkConnection;
 import org.verdictdb.coordinator.ExecutionContext;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.sqlobject.CreateSchemaQuery;
-import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.metastore.CachedScrambleMetaStore;
 import org.verdictdb.metastore.ScrambleMetaStore;
 import org.verdictdb.metastore.VerdictMetaStore;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntaxList;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
 
 public class VerdictContext {
 
@@ -97,24 +96,23 @@ public class VerdictContext {
     query.setIfNotExists(true);
     conn.execute(query);
   }
-  
+
   /**
    * Initializes VerdictContext from a SparkSession instance.
-   * 
-   * @param spark The actual type must be SparkSession; however, the type must not explicitly
-   * appear in this file. If it does, it causes a ClassNotFound error when VerdictContext is used
-   * for JDBC connection (i.e., when not submitted to any Spark cluster) because SparkSession
-   * is imported as "provided" scope in our maven dependency list.
-   * 
+   *
+   * @param spark The actual type must be SparkSession; however, the type must not explicitly appear
+   *     in this file. If it does, it causes a ClassNotFound error when VerdictContext is used for
+   *     JDBC connection (i.e., when not submitted to any Spark cluster) because SparkSession is
+   *     imported as "provided" scope in our maven dependency list.
    * @return
-   * @throws VerdictDBException 
+   * @throws VerdictDBException
    */
   public static VerdictContext fromSparkSession(Object spark) throws VerdictDBException {
     DbmsConnection conn = new SparkConnection(spark);
     return new VerdictContext(conn);
   }
-  
-  public static VerdictContext fromSparkSession(Object spark, VerdictOption option) 
+
+  public static VerdictContext fromSparkSession(Object spark, VerdictOption option)
       throws VerdictDBException {
     DbmsConnection conn = new SparkConnection(spark);
     return new VerdictContext(conn, option);
@@ -126,10 +124,9 @@ public class VerdictContext {
    *
    * @param jdbcConn
    * @return
-   * @throws VerdictDBException 
+   * @throws VerdictDBException
    */
-  public static VerdictContext fromJdbcConnection(Connection jdbcConn)
-      throws VerdictDBException {
+  public static VerdictContext fromJdbcConnection(Connection jdbcConn) throws VerdictDBException {
     DbmsConnection conn = JdbcConnection.create(jdbcConn);
     return new VerdictContext(conn);
   }
@@ -330,7 +327,7 @@ public class VerdictContext {
    */
   public VerdictSingleResult sql(String query) throws VerdictDBException {
     ExecutionContext exec = createNewExecutionContext();
-    VerdictSingleResult result = exec.sql(query);
+    VerdictSingleResult result = exec.sql(query, false);
     removeExecutionContext(exec);
     return result;
   }

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -122,7 +122,11 @@ public class ExecutionContext {
 
   public VerdictSingleResult sql(String query, boolean getResult) throws VerdictDBException {
     QueryType queryType = identifyQueryType(query);
-    if (queryType != QueryType.select && getResult) {
+    if ((queryType != QueryType.select &&
+        queryType != QueryType.show_databases &&
+        queryType != QueryType.show_tables &&
+        queryType != QueryType.describe_table
+    ) && getResult) {
       throw new VerdictDBException(
           "Can not issue data manipulation statements with executeQuery().");
     }

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -121,19 +121,20 @@ public class ExecutionContext {
   }
 
   public VerdictSingleResult sql(String query, boolean getResult) throws VerdictDBException {
-    QueryType queryType = identifyQueryType(query);
-    if ((queryType != QueryType.select &&
-        queryType != QueryType.show_databases &&
-        queryType != QueryType.show_tables &&
-        queryType != QueryType.describe_table
-    ) && getResult) {
-      throw new VerdictDBException(
-          "Can not issue data manipulation statements with executeQuery().");
-    }
     String bypassSql = checkBypass(query);
     if (bypassSql != null) {
       return executeAsIs(bypassSql);
     } else {
+      QueryType queryType = identifyQueryType(query);
+      if ((queryType != QueryType.select
+              && queryType != QueryType.show_databases
+              && queryType != QueryType.show_tables
+              && queryType != QueryType.describe_table)
+          && getResult) {
+        throw new VerdictDBException(
+            "Can not issue data manipulation statements with executeQuery().");
+      }
+
       VerdictResultStream stream = streamsql(query);
       if (stream == null) {
         return null;

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -16,12 +16,6 @@
 
 package org.verdictdb.coordinator;
 
-import static org.verdictdb.coordinator.VerdictSingleResultFromListData.createWithSingleColumn;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.VerdictResultStream;
@@ -44,6 +38,12 @@ import org.verdictdb.parser.VerdictSQLParser;
 import org.verdictdb.parser.VerdictSQLParserBaseVisitor;
 import org.verdictdb.sqlreader.NonValidatingSQLParser;
 import org.verdictdb.sqlreader.RelationGen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.verdictdb.coordinator.VerdictSingleResultFromListData.createWithSingleColumn;
 
 /**
  * Stores the context for a single query execution. Includes both scrambling query and select query.
@@ -83,7 +83,11 @@ public class ExecutionContext {
    * @param options
    */
   public ExecutionContext(
-      DbmsConnection conn, VerdictMetaStore metaStore, String contextId, long serialNumber, VerdictOption options) {
+      DbmsConnection conn,
+      VerdictMetaStore metaStore,
+      String contextId,
+      long serialNumber,
+      VerdictOption options) {
     this.conn = conn;
     this.metaStore = metaStore;
     this.serialNumber = serialNumber;
@@ -113,6 +117,15 @@ public class ExecutionContext {
   }
 
   public VerdictSingleResult sql(String query) throws VerdictDBException {
+    return this.sql(query, true);
+  }
+
+  public VerdictSingleResult sql(String query, boolean getResult) throws VerdictDBException {
+    QueryType queryType = identifyQueryType(query);
+    if (queryType != QueryType.select && getResult) {
+      throw new VerdictDBException(
+          "Can not issue data manipulation statements with executeQuery().");
+    }
     String bypassSql = checkBypass(query);
     if (bypassSql != null) {
       return executeAsIs(bypassSql);
@@ -130,20 +143,20 @@ public class ExecutionContext {
       } finally {
         stream.close();
         abort();
-//        abortInParallel(stream);
+        //        abortInParallel(stream);
       }
     }
   }
-  
+
   private void abortInParallel(VerdictResultStream stream) {
     Thread task = new Thread(new ConcurrentAborter(stream));
     task.start();
   }
-  
+
   class ConcurrentAborter implements Runnable {
-    
+
     VerdictResultStream stream;
-    
+
     public ConcurrentAborter(VerdictResultStream stream) {
       this.stream = stream;
     }
@@ -153,7 +166,6 @@ public class ExecutionContext {
       stream.close();
       abort();
     }
-    
   }
 
   public VerdictResultStream streamsql(String query) throws VerdictDBException {
@@ -163,8 +175,7 @@ public class ExecutionContext {
     if (queryType.equals(QueryType.select)) {
       log.debug("Query type: select");
       ScrambleMetaSet metaset = metaStore.retrieve();
-      SelectQueryCoordinator coordinator =
-          new SelectQueryCoordinator(conn, metaset, options);
+      SelectQueryCoordinator coordinator = new SelectQueryCoordinator(conn, metaset, options);
       runningCoordinator = coordinator;
 
       ExecutionResultReader reader = coordinator.process(query, queryContext);
@@ -176,8 +187,10 @@ public class ExecutionContext {
       CreateScrambleQuery scrambleQuery = generateScrambleQuery(query);
       ScramblingCoordinator scrambler =
           new ScramblingCoordinator(
-              conn, scrambleQuery.getNewSchema(), 
-              options.getVerdictTempSchemaName(), scrambleQuery.getBlockSize());
+              conn,
+              scrambleQuery.getNewSchema(),
+              options.getVerdictTempSchemaName(),
+              scrambleQuery.getBlockSize());
 
       // Specifying size/ratio of scrambled table is not supported.
       if (scrambleQuery.getSize() != 1.0) {
@@ -198,22 +211,22 @@ public class ExecutionContext {
       log.debug("Query type: set_default_schema");
       updateDefaultSchemaFromQuery(query);
       return null;
-      
+
     } else if (queryType.equals(QueryType.show_databases)) {
       log.debug("Query type: show_databases");
       VerdictResultStream stream = generateShowSchemaResultFromQuery();
       return stream;
-      
+
     } else if (queryType.equals(QueryType.show_tables)) {
       log.debug("Query type: show_tables");
       VerdictResultStream stream = generateShowTablesResultFromQuery(query);
       return stream;
-      
+
     } else if (queryType.equals(QueryType.describe_table)) {
       log.debug("Query type: describe_table");
       VerdictResultStream stream = generateDesribeTableResultFromQuery(query);
       return stream;
-      
+
     } else {
       throw new VerdictDBTypeException("Unexpected type of query: " + query);
     }
@@ -228,38 +241,38 @@ public class ExecutionContext {
     VerdictSQLParser parser = NonValidatingSQLParser.parserOf(query);
     VerdictSQLParserBaseVisitor<CreateScrambleQuery> visitor =
         new VerdictSQLParserBaseVisitor<CreateScrambleQuery>() {
-      @Override
-      public CreateScrambleQuery visitCreate_scramble_statement(
-          VerdictSQLParser.Create_scramble_statementContext ctx) {
-        RelationGen g = new RelationGen();
-        BaseTable originalTable = (BaseTable) g.visit(ctx.original_table);
-        BaseTable scrambleTable = (BaseTable) g.visit(ctx.scrambled_table);
-        String method =
-            (ctx.scrambling_method_name() == null)
-            ? "uniform"
-                : ctx.scrambling_method_name()
-                .getText()
-                .replace("'", "")
-                .replace("\"", "")
-                .replace("`", ""); // remove all types of 'quotes'
-        double percent =
-            (ctx.percent == null) ? 1.0 : Double.parseDouble(ctx.percent.getText());
-        long blocksize =
-            (ctx.blocksize == null) ? (long) 1e6 : Long.parseLong(ctx.blocksize.getText());
-        
-        CreateScrambleQuery query =
-            new CreateScrambleQuery(
-                scrambleTable.getSchemaName(),
-                scrambleTable.getTableName(),
-                originalTable.getSchemaName(),
-                originalTable.getTableName(),
-                method,
-                percent,
-                blocksize);
-        if (ctx.IF() != null) query.setIfNotExists(true);
-        return query;
-      }
-    };
+          @Override
+          public CreateScrambleQuery visitCreate_scramble_statement(
+              VerdictSQLParser.Create_scramble_statementContext ctx) {
+            RelationGen g = new RelationGen();
+            BaseTable originalTable = (BaseTable) g.visit(ctx.original_table);
+            BaseTable scrambleTable = (BaseTable) g.visit(ctx.scrambled_table);
+            String method =
+                (ctx.scrambling_method_name() == null)
+                    ? "uniform"
+                    : ctx.scrambling_method_name()
+                        .getText()
+                        .replace("'", "")
+                        .replace("\"", "")
+                        .replace("`", ""); // remove all types of 'quotes'
+            double percent =
+                (ctx.percent == null) ? 1.0 : Double.parseDouble(ctx.percent.getText());
+            long blocksize =
+                (ctx.blocksize == null) ? (long) 1e6 : Long.parseLong(ctx.blocksize.getText());
+
+            CreateScrambleQuery query =
+                new CreateScrambleQuery(
+                    scrambleTable.getSchemaName(),
+                    scrambleTable.getTableName(),
+                    originalTable.getSchemaName(),
+                    originalTable.getTableName(),
+                    method,
+                    percent,
+                    blocksize);
+            if (ctx.IF() != null) query.setIfNotExists(true);
+            return query;
+          }
+        };
 
     CreateScrambleQuery scrambleQuery = visitor.visit(parser.create_scramble_statement());
     return scrambleQuery;
@@ -287,17 +300,17 @@ public class ExecutionContext {
     VerdictSQLParser parser = NonValidatingSQLParser.parserOf(query);
     VerdictSQLParserBaseVisitor<Pair<String, String>> visitor =
         new VerdictSQLParserBaseVisitor<Pair<String, String>>() {
-      @Override
-      public Pair<String, String> visitDescribe_table_statement(
-          VerdictSQLParser.Describe_table_statementContext ctx) {
-        String table = ctx.table.table.getText();
-        String schema = ctx.table.schema.getText();
-        if (schema == null) {
-          schema = conn.getDefaultSchema();
-        }
-        return new ImmutablePair<>(schema, table);
-      }
-    };
+          @Override
+          public Pair<String, String> visitDescribe_table_statement(
+              VerdictSQLParser.Describe_table_statementContext ctx) {
+            String table = ctx.table.table.getText();
+            String schema = ctx.table.schema.getText();
+            if (schema == null) {
+              schema = conn.getDefaultSchema();
+            }
+            return new ImmutablePair<>(schema, table);
+          }
+        };
     Pair<String, String> t = visitor.visit(parser.verdict_statement());
     String table = t.getRight();
     String schema = t.getLeft();
@@ -361,7 +374,8 @@ public class ExecutionContext {
       //        rs =
       //            conn.execute(
       //                String.format(
-      //                    "SELECT * FROM information_schema.tables WHERE table_schema = '%s'", schema));
+      //                    "SELECT * FROM information_schema.tables WHERE table_schema = '%s'",
+      // schema));
       //      } else {
       //        rs = conn.execute(String.format("show tables in %s", schema));
       //      }
@@ -386,40 +400,40 @@ public class ExecutionContext {
     VerdictSQLParserBaseVisitor<QueryType> visitor =
         new VerdictSQLParserBaseVisitor<QueryType>() {
 
-      @Override
-      public QueryType visitSelect_statement(VerdictSQLParser.Select_statementContext ctx) {
-        return QueryType.select;
-      }
+          @Override
+          public QueryType visitSelect_statement(VerdictSQLParser.Select_statementContext ctx) {
+            return QueryType.select;
+          }
 
-      @Override
-      public QueryType visitCreate_scramble_statement(
-          VerdictSQLParser.Create_scramble_statementContext ctx) {
-        return QueryType.scrambling;
-      }
+          @Override
+          public QueryType visitCreate_scramble_statement(
+              VerdictSQLParser.Create_scramble_statementContext ctx) {
+            return QueryType.scrambling;
+          }
 
-      @Override
-      public QueryType visitUse_statement(VerdictSQLParser.Use_statementContext ctx) {
-        return QueryType.set_default_schema;
-      }
+          @Override
+          public QueryType visitUse_statement(VerdictSQLParser.Use_statementContext ctx) {
+            return QueryType.set_default_schema;
+          }
 
-      @Override
-      public QueryType visitShow_databases_statement(
-          VerdictSQLParser.Show_databases_statementContext ctx) {
-        return QueryType.show_databases;
-      }
+          @Override
+          public QueryType visitShow_databases_statement(
+              VerdictSQLParser.Show_databases_statementContext ctx) {
+            return QueryType.show_databases;
+          }
 
-      @Override
-      public QueryType visitShow_tables_statement(
-          VerdictSQLParser.Show_tables_statementContext ctx) {
-        return QueryType.show_tables;
-      }
+          @Override
+          public QueryType visitShow_tables_statement(
+              VerdictSQLParser.Show_tables_statementContext ctx) {
+            return QueryType.show_tables;
+          }
 
-      @Override
-      public QueryType visitDescribe_table_statement(
-          VerdictSQLParser.Describe_table_statementContext ctx) {
-        return QueryType.describe_table;
-      }
-    };
+          @Override
+          public QueryType visitDescribe_table_statement(
+              VerdictSQLParser.Describe_table_statementContext ctx) {
+            return QueryType.describe_table;
+          }
+        };
 
     QueryType type = visitor.visit(parser.verdict_statement());
     return type;

--- a/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
+++ b/src/main/java/org/verdictdb/jdbc41/VerdictStatement.java
@@ -16,16 +16,16 @@
 
 package org.verdictdb.jdbc41;
 
+import org.verdictdb.VerdictContext;
+import org.verdictdb.VerdictSingleResult;
+import org.verdictdb.coordinator.ExecutionContext;
+import org.verdictdb.exception.VerdictDBException;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
-
-import org.verdictdb.VerdictContext;
-import org.verdictdb.VerdictSingleResult;
-import org.verdictdb.coordinator.ExecutionContext;
-import org.verdictdb.exception.VerdictDBException;
 
 public class VerdictStatement implements java.sql.Statement {
 
@@ -43,7 +43,7 @@ public class VerdictStatement implements java.sql.Statement {
   @Override
   public boolean execute(String sql) throws SQLException {
     try {
-      result = executionContext.sql(sql);
+      result = executionContext.sql(sql, false);
       if (result == null) {
         return false;
       }


### PR DESCRIPTION
This pull request attempts to fix #263.