### PR TITLE
Add support for dropping scrambled tables

### DIFF
--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -51,7 +51,8 @@ options { tokenVocab=VerdictSQLLexer; }
 verdict_statement
     : select_statement
     | create_scramble_statement
-    | delete_scramble_statement
+    | drop_scramble_statement
+    | drop_all_scrambles_statement
     | show_scrambles_statement
     | config_statement
     | other_statement
@@ -78,9 +79,13 @@ on_columns
     : ON column_name (',' column_name)*
     ;
 
-delete_scramble_statement
-    : DROP SCRAMBLE original_table=table_name
+drop_scramble_statement
+    : DROP SCRAMBLE scrambled_table=table_name ON original_table=table_name
     ;
+
+drop_all_scrambles_statement
+	: DROP ALL SCRAMBLE original_table=table_name
+	;
 
 show_scrambles_statement
     : SHOW SCRAMBLES

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -132,7 +132,8 @@ public class ExecutionContext {
       if ((queryType != QueryType.select
               && queryType != QueryType.show_databases
               && queryType != QueryType.show_tables
-              && queryType != QueryType.describe_table)
+              && queryType != QueryType.describe_table
+              && queryType != QueryType.show_scrambles)
           && getResult) {
         throw new VerdictDBException(
             "Can not issue data manipulation statements with executeQuery().");

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -66,6 +66,8 @@ public class ScrambleMetaStore extends VerdictMetaStore {
 
   private static final String DELETED = "DELETED";
 
+  private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
   private DbmsConnection conn;
 
   private String storeSchema;
@@ -177,7 +179,7 @@ public class ScrambleMetaStore extends VerdictMetaStore {
     InsertValuesQuery insertQuery = new InsertValuesQuery();
     insertQuery.setSchemaName(getStoreSchema());
     insertQuery.setTableName(getMetaStoreTableName());
-    String timeStamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+    String timeStamp = new SimpleDateFormat(TIMESTAMP_FORMAT).format(new Date());
     insertQuery.setValues(
         Arrays.<Object>asList(
             originalTableSchema,
@@ -270,7 +272,7 @@ public class ScrambleMetaStore extends VerdictMetaStore {
     String scrambleSchema = meta.getSchemaName();
     String scrambleTable = meta.getTableName();
     String scrambleMethod = meta.getMethod();
-    String timeStamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+    String timeStamp = new SimpleDateFormat(TIMESTAMP_FORMAT).format(new Date());
     String jsonString = meta.toJsonString();
     query.setValues(
         Arrays.<Object>asList(

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -16,16 +16,14 @@
 
 package org.verdictdb.metastore;
 
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.verdictdb.VerdictSingleResult;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.DbmsQueryResult;
+import org.verdictdb.coordinator.VerdictSingleResultFromDbmsQueryResult;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 import org.verdictdb.core.sqlobject.BaseColumn;
@@ -39,6 +37,14 @@ import org.verdictdb.core.sqlobject.SelectItem;
 import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlwriter.QueryToSql;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 public class ScrambleMetaStore extends VerdictMetaStore {
 
@@ -57,6 +63,8 @@ public class ScrambleMetaStore extends VerdictMetaStore {
   private static final String ADDED_AT_COLUMN = "added_at";
 
   private static final String DATA_COLUMN = "data";
+
+  private static final String DELETED = "DELETED";
 
   private DbmsConnection conn;
 
@@ -115,6 +123,74 @@ public class ScrambleMetaStore extends VerdictMetaStore {
     addToStore(scrambleMetaSet);
   }
 
+  public VerdictSingleResult showScrambles() throws VerdictDBException {
+    String tableAlias = "t";
+    SelectQuery query =
+        SelectQuery.create(
+            Arrays.<SelectItem>asList(
+                new BaseColumn(tableAlias, ORIGINAL_SCHEMA_COLUMN),
+                new BaseColumn(tableAlias, ORIGINAL_TABLE_COLUMN),
+                new BaseColumn(tableAlias, SCRAMBLE_SCHEMA_COLUMN),
+                new BaseColumn(tableAlias, SCRAMBLE_TABLE_COLUMN),
+                new BaseColumn(tableAlias, ADDED_AT_COLUMN),
+                new BaseColumn(tableAlias, DATA_COLUMN)),
+            new BaseTable(storeSchema, METASTORE_TABLE_NAME, tableAlias));
+    query.addOrderby(new OrderbyAttribute(ADDED_AT_COLUMN, "desc"));
+    String sql = QueryToSql.convert(conn.getSyntax(), query);
+    DbmsQueryResult result = conn.execute(sql);
+
+    return new VerdictSingleResultFromDbmsQueryResult(result);
+  }
+
+  public void dropAllScrambleTable(BaseTable originalTable) throws VerdictDBException {
+    String originalTableSchema = originalTable.getSchemaName();
+    String originalTableName = originalTable.getTableName();
+    ScrambleMetaSet metaSet = this.retrieve();
+
+    for (Iterator<ScrambleMeta> it = metaSet.iterator(); it.hasNext(); ) {
+      ScrambleMeta meta = it.next();
+      if (meta.getOriginalTableName().equals(originalTableName)
+          && meta.getOriginalSchemaName().equals(originalTableSchema)) {
+        String scrambleTableSchema = meta.getSchemaName();
+        String scrambleTableName = meta.getTableName();
+        this.dropScrambleTable(
+            new BaseTable(originalTableSchema, originalTableName),
+            new BaseTable(scrambleTableSchema, scrambleTableName));
+      }
+    }
+  }
+
+  public void dropScrambleTable(BaseTable originalTable, BaseTable scrambleTable)
+      throws VerdictDBException {
+    String originalTableSchema = originalTable.getSchemaName();
+    String originalTableName = originalTable.getTableName();
+    String scrambleTableSchema = scrambleTable.getSchemaName();
+    String scrambleTableName = scrambleTable.getTableName();
+
+    // drop the actual scrambled table first.
+    DropTableQuery dropQuery = new DropTableQuery(scrambleTableSchema, scrambleTableName);
+    dropQuery.setIfExists(true);
+    String sql = QueryToSql.convert(conn.getSyntax(), dropQuery);
+    conn.execute(sql);
+
+    // update metadata with a new row where 'data' and 'method' marked as 'DELETED'
+    InsertValuesQuery insertQuery = new InsertValuesQuery();
+    insertQuery.setSchemaName(getStoreSchema());
+    insertQuery.setTableName(getMetaStoreTableName());
+    String timeStamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+    insertQuery.setValues(
+        Arrays.<Object>asList(
+            originalTableSchema,
+            originalTableName,
+            scrambleTableSchema,
+            scrambleTableName,
+            "DELETED",
+            timeStamp,
+            "DELETED"));
+    sql = QueryToSql.convert(conn.getSyntax(), insertQuery);
+    conn.execute(sql);
+  }
+
   public void remove() throws VerdictDBException {
     // create a schema if not exists
     CreateSchemaQuery createSchemaQuery = new CreateSchemaQuery(storeSchema);
@@ -136,7 +212,7 @@ public class ScrambleMetaStore extends VerdictMetaStore {
    */
   public void addToStore(ScrambleMetaSet scrambleMetaSet) throws VerdictDBException {
     String sql;
-    
+
     // create a schema if not exists
     if (!conn.getSchemas().contains(storeSchema)) {
       CreateSchemaQuery createSchemaQuery = new CreateSchemaQuery(storeSchema);
@@ -215,56 +291,18 @@ public class ScrambleMetaStore extends VerdictMetaStore {
    */
   @Override
   public ScrambleMetaSet retrieve() {
-    ScrambleMetaSet retrieved = new ScrambleMetaSet();
-
-    try {
-      String storeSchema = getStoreSchema();
-      String storeTable = getMetaStoreTableName();
-
-      List<String> existingSchemas = conn.getSchemas();
-      if (existingSchemas.contains(storeSchema) == false) {
-        return new ScrambleMetaSet();
-      }
-
-      List<String> existingTables = conn.getTables(storeSchema);
-      if (existingTables.contains(storeTable) == false) {
-        return new ScrambleMetaSet();
-      }
-
-      // now ready to retrieve
-      String tableAlias = "t";
-      SelectQuery query =
-          SelectQuery.create(
-              Arrays.<SelectItem>asList(
-                  new BaseColumn(tableAlias, ADDED_AT_COLUMN),
-                  new BaseColumn(tableAlias, DATA_COLUMN)),
-              new BaseTable(storeSchema, storeTable, tableAlias));
-      query.addOrderby(new OrderbyAttribute(ADDED_AT_COLUMN));
-      String sql = QueryToSql.convert(conn.getSyntax(), query);
-      DbmsQueryResult result = conn.execute(sql);
-
-      while (result.next()) {
-        String jsonString = result.getString(1);
-        ScrambleMeta meta = ScrambleMeta.fromJsonString(jsonString);
-        retrieved.addScrambleMeta(meta);
-      }
-    } catch (VerdictDBException e) {
-      e.printStackTrace();
-    }
-
-    return retrieved;
+    return retrieve(conn, getStoreSchema());
   }
 
   /**
-   * Static version of retrieve() that uses default schema and table names
+   * Static version of retrieve()
    *
    * @return a set of scramble meta
    */
-  public static ScrambleMetaSet retrieve(DbmsConnection conn, VerdictOption options) {
+  public static ScrambleMetaSet retrieve(DbmsConnection conn, String storeSchema) {
     ScrambleMetaSet retrieved = new ScrambleMetaSet();
 
     try {
-      String storeSchema = options.getVerdictMetaSchemaName();
       String storeTable = METASTORE_TABLE_NAME;
 
       List<String> existingSchemas = conn.getSchemas();
@@ -282,15 +320,35 @@ public class ScrambleMetaStore extends VerdictMetaStore {
       SelectQuery query =
           SelectQuery.create(
               Arrays.<SelectItem>asList(
+                  new BaseColumn(tableAlias, ORIGINAL_SCHEMA_COLUMN),
+                  new BaseColumn(tableAlias, ORIGINAL_TABLE_COLUMN),
+                  new BaseColumn(tableAlias, SCRAMBLE_SCHEMA_COLUMN),
+                  new BaseColumn(tableAlias, SCRAMBLE_TABLE_COLUMN),
                   new BaseColumn(tableAlias, ADDED_AT_COLUMN),
                   new BaseColumn(tableAlias, DATA_COLUMN)),
               new BaseTable(storeSchema, storeTable, tableAlias));
-      query.addOrderby(new OrderbyAttribute(ADDED_AT_COLUMN));
+      query.addOrderby(new OrderbyAttribute(ADDED_AT_COLUMN, "desc"));
       String sql = QueryToSql.convert(conn.getSyntax(), query);
       DbmsQueryResult result = conn.execute(sql);
 
+      Set<Pair<BaseTable, BaseTable>> deletedSet = new HashSet<>();
+
       while (result.next()) {
-        String jsonString = result.getString(1);
+        String originalSchema = result.getString(0);
+        String originalTable = result.getString(1);
+        String scrambleSchema = result.getString(2);
+        String scrambleTable = result.getString(3);
+        BaseTable original = new BaseTable(originalSchema, originalTable);
+        BaseTable scramble = new BaseTable(scrambleSchema, scrambleTable);
+        Pair<BaseTable, BaseTable> pair = ImmutablePair.of(original, scramble);
+        String jsonString = result.getString(5);
+        if (jsonString.toUpperCase().equals(DELETED)) {
+          deletedSet.add(pair);
+        }
+        // skip the scrambled table has been deleted
+        if (deletedSet.contains(pair)) {
+          continue;
+        }
         ScrambleMeta meta = ScrambleMeta.fromJsonString(jsonString);
         retrieved.addScrambleMeta(meta);
       }

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -184,9 +184,9 @@ public class ScrambleMetaStore extends VerdictMetaStore {
             originalTableName,
             scrambleTableSchema,
             scrambleTableName,
-            "DELETED",
+            DELETED,
             timeStamp,
-            "DELETED"));
+            DELETED));
     sql = QueryToSql.convert(conn.getSyntax(), insertQuery);
     conn.execute(sql);
   }

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -180,7 +180,7 @@ public class RedshiftScrambleManipulationTest {
   }
 
   @Test
-  public void DropAllScramblesTest() throws SQLException {
+  public void DropAllScramblesTest() throws SQLException, InterruptedException {
     vc.createStatement()
         .execute(
             String.format(
@@ -189,6 +189,8 @@ public class RedshiftScrambleManipulationTest {
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble6 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
+    // give 0.5 sec delay between creation and deletion of scrambled table
+    Thread.sleep(500);
     String sql = String.format("DROP ALL SCRAMBLE %s.orders", SCHEMA_NAME);
     vc.createStatement().execute(sql);
 
@@ -223,7 +225,8 @@ public class RedshiftScrambleManipulationTest {
   }
 
   @Test
-  public void DropScrambleAndGetScrambleMetaSetTest() throws SQLException, VerdictDBDbmsException {
+  public void DropScrambleAndGetScrambleMetaSetTest()
+      throws SQLException, VerdictDBDbmsException, InterruptedException {
 
     // drop all scrambled tables first.
     String sql = String.format("DROP ALL SCRAMBLE %s.orders", SCHEMA_NAME);
@@ -238,6 +241,8 @@ public class RedshiftScrambleManipulationTest {
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble8 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
+    // give 0.5 sec delay between creation and deletion of scrambled table
+    Thread.sleep(500);
 
     sql = String.format("DROP SCRAMBLE %s.orders_scramble7 ON %s.orders", SCHEMA_NAME, SCHEMA_NAME);
     vc.createStatement().execute(sql);

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -146,8 +146,6 @@ public class RedshiftScrambleManipulationTest {
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble4 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
-    // give 0.5 sec delay between creation and deletion of scrambled table
-    Thread.sleep(500);
     String sql =
         String.format("DROP SCRAMBLE %s.orders_scramble4 ON %s.orders", SCHEMA_NAME, SCHEMA_NAME);
     vc.createStatement().execute(sql);
@@ -189,8 +187,6 @@ public class RedshiftScrambleManipulationTest {
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble6 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
-    // give 0.5 sec delay between creation and deletion of scrambled table
-    Thread.sleep(500);
     String sql = String.format("DROP ALL SCRAMBLE %s.orders", SCHEMA_NAME);
     vc.createStatement().execute(sql);
 
@@ -241,8 +237,6 @@ public class RedshiftScrambleManipulationTest {
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble8 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
-    // give 0.5 sec delay between creation and deletion of scrambled table
-    Thread.sleep(500);
 
     sql = String.format("DROP SCRAMBLE %s.orders_scramble7 ON %s.orders", SCHEMA_NAME, SCHEMA_NAME);
     vc.createStatement().execute(sql);

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -165,13 +165,13 @@ public class RedshiftScrambleManipulationTest {
     ResultSet rs = vc.createStatement().executeQuery(sql);
     int rowCount = 0;
     while (rs.next()) {
-      assertEquals(rs.getString(1), SCHEMA_NAME);
-      assertEquals(rs.getString(2), "orders");
-      assertEquals(rs.getString(3), SCHEMA_NAME);
+      assertEquals(SCHEMA_NAME, rs.getString(1));
+      assertEquals("orders", rs.getString(2));
+      assertEquals(SCHEMA_NAME, rs.getString(3));
       String scrambleName = rs.getString(4);
       assertTrue(scrambleName.startsWith("orders_scramble"));
       if (scrambleName.equals("orders_scramble4") && rowCount == 0) {
-        assertEquals(rs.getString(6), "DELETED");
+        assertEquals("DELETED", rs.getString(6));
       }
       ++rowCount;
     }
@@ -207,9 +207,9 @@ public class RedshiftScrambleManipulationTest {
     Set<String> deleted = new HashSet<>();
     int rowCount = 0;
     while (rs.next()) {
-      assertEquals(rs.getString(1), SCHEMA_NAME);
-      assertEquals(rs.getString(2), "orders");
-      assertEquals(rs.getString(3), SCHEMA_NAME);
+      assertEquals(SCHEMA_NAME, rs.getString(1));
+      assertEquals("orders", rs.getString(2));
+      assertEquals(SCHEMA_NAME, rs.getString(3));
       String scrambleName = rs.getString(4);
       assertTrue(scrambleName.startsWith("orders_scramble"));
       if (!deleted.contains(scrambleName)) {

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -141,11 +141,13 @@ public class RedshiftScrambleManipulationTest {
   }
 
   @Test
-  public void DropScrambleTest() throws SQLException {
+  public void DropScrambleTest() throws SQLException, InterruptedException {
     vc.createStatement()
         .execute(
             String.format(
                 "CREATE SCRAMBLE %s.orders_scramble4 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
+    // give 0.5 sec delay between creation and deletion of scrambled table
+    Thread.sleep(500);
     String sql =
         String.format("DROP SCRAMBLE %s.orders_scramble4 ON %s.orders", SCHEMA_NAME, SCHEMA_NAME);
     vc.createStatement().execute(sql);


### PR DESCRIPTION
(Ref: #265) 
Adds support for the following three query syntaxes:

1. DROP SCRAMBLE `scrambled_table` ON `original_table` : drops a single scrambled table `scrambled_table`
2. DROP ALL SCRAMBLE `original_table` : drops all scrambled table built for `original_table`
3. SHOW SCRAMBLES : show all scrambled tables (basically `select * from verdictdbmeta`)

This pull request also includes a unit test that tests all three types of queries.