### PR TITLE
Enable partitioning for temporary tables with Presto + Hive

### DIFF
--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -68,7 +68,7 @@ verdict_statement
 create_scramble_statement
     : CREATE SCRAMBLE (IF NOT EXISTS)? scrambled_table=table_name FROM original_table=table_name
       (METHOD scrambling_method_name)? 
-      (SIZE percent=(FLOAT | DECIMAL) '%')? 
+      (SIZE percent=FLOAT)?
       (BLOCKSIZE blocksize=DECIMAL)?
     ;
 

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -206,10 +206,10 @@ public class ExecutionContext {
               scrambleQuery.getBlockSize());
 
       // Specifying size/ratio of scrambled table is not supported.
-      if (scrambleQuery.getSize() != 1.0) {
-        throw new VerdictDBTypeException(
-            String.format("Scramble size of %f not supported.", scrambleQuery.getSize()));
-      }
+      //      if (scrambleQuery.getSize() != 1.0) {
+      //        throw new VerdictDBTypeException(
+      //            String.format("Scramble size of %f not supported.", scrambleQuery.getSize()));
+      //      }
 
       // store this to our own metadata db.
       ScrambleMeta meta = scrambler.scramble(scrambleQuery);

--- a/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
@@ -88,7 +88,7 @@ public class ScramblingCoordinator {
     this.scratchpadSchema = Optional.fromNullable(scratchpadSchema);
     this.scrambleSchema = Optional.fromNullable(scrambleSchema);
     if (blockSize != null) {
-      options.put("scrambleTableBlockSize", String.valueOf(blockSize));
+      options.put("minScrambleTableBlockSize", String.valueOf(blockSize));
     }
   }
 

--- a/src/main/java/org/verdictdb/core/scrambling/CreateScrambledTableNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/CreateScrambledTableNode.java
@@ -16,9 +16,6 @@
 
 package org.verdictdb.core.scrambling;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.execplan.ExecutionInfoToken;
@@ -29,6 +26,9 @@ import org.verdictdb.core.sqlobject.CreateScrambledTableQuery;
 import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.SqlConvertible;
 import org.verdictdb.exception.VerdictDBException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** Created by Dong Young Yoon on 7/17/18. */
 public class CreateScrambledTableNode extends QueryNodeWithPlaceHolders {
@@ -124,6 +124,7 @@ public class CreateScrambledTableNode extends QueryNodeWithPlaceHolders {
             blockColumnName,
             selectQuery,
             method.getBlockCount(),
+            method.getRelativeSize(),
             columnMeta,
             createIfNotExists);
     for (String col : partitionColumns) {

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethod.java
@@ -16,12 +16,12 @@
 
 package org.verdictdb.core.scrambling;
 
-import java.util.List;
-import java.util.Map;
-
 import org.verdictdb.core.querying.ExecutableNodeBase;
 import org.verdictdb.core.sqlobject.AbstractRelation;
 import org.verdictdb.core.sqlobject.UnnamedColumn;
+
+import java.util.List;
+import java.util.Map;
 
 public interface ScramblingMethod {
 
@@ -39,6 +39,8 @@ public interface ScramblingMethod {
   public int getBlockCount();
 
   public int getTierCount();
+
+  public double getRelativeSize();
 
   public List<Double> getStoredCumulativeProbabilityDistributionForTier(int tier);
 

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
@@ -22,12 +22,18 @@ import java.util.Map;
 
 public abstract class ScramblingMethodBase implements ScramblingMethod {
 
-  protected final long blockSize;
+  protected long blockSize;
+
+  protected final int maxBlockCount;
+
+  protected final double relativeSize; // size relative to original table (0.0 ~ 1.0)
 
   private final Map<Integer, List<Double>> storedProbDist = new HashMap<>();
 
-  public ScramblingMethodBase(long blockSize) {
+  public ScramblingMethodBase(long blockSize, int maxBlockCount, double relativeSize) {
     this.blockSize = blockSize;
+    this.maxBlockCount = maxBlockCount;
+    this.relativeSize = relativeSize;
   }
 
   long getBlockSize() {

--- a/src/main/java/org/verdictdb/core/sqlobject/CreateScrambledTableQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateScrambledTableQuery.java
@@ -16,14 +16,14 @@
 
 package org.verdictdb.core.sqlobject;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Example: CRAETE TABLE test1 PARTITION OF test FOR VALUES IN (1);
@@ -52,6 +52,8 @@ public class CreateScrambledTableQuery extends CreateTableQuery {
 
   protected int blockCount = 1;
 
+  protected double relativeSize = 1.0;
+
   public CreateScrambledTableQuery(
       String originalSchemaName,
       String originalTableName,
@@ -61,6 +63,7 @@ public class CreateScrambledTableQuery extends CreateTableQuery {
       String blockColumnName,
       SelectQuery select,
       int blockCount,
+      double relativeSize,
       List<Pair<String, String>> columnMeta,
       boolean createIfNotExists) {
     this.originalSchemaName = originalSchemaName;
@@ -71,6 +74,7 @@ public class CreateScrambledTableQuery extends CreateTableQuery {
     this.blockColumnName = blockColumnName;
     this.select = select;
     this.blockCount = blockCount;
+    this.relativeSize = relativeSize;
     this.columnMeta = columnMeta;
     this.overwrite = createIfNotExists;
   }
@@ -121,6 +125,10 @@ public class CreateScrambledTableQuery extends CreateTableQuery {
 
   public List<Pair<String, String>> getColumnMeta() {
     return columnMeta;
+  }
+
+  public double getRelativeSize() {
+    return relativeSize;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/core/sqlobject/CreateTableAsSelectQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateTableAsSelectQuery.java
@@ -16,13 +16,13 @@
 
 package org.verdictdb.core.sqlobject;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents a create table query.
@@ -35,12 +35,14 @@ public class CreateTableAsSelectQuery extends CreateTableQuery {
 
   private static final long serialVersionUID = -4077488589201481833L;
 
+  protected CreateTableQuery originalQuery;
+
   protected SelectQuery select;
 
   protected List<String> partitionColumns = new ArrayList<>();
-  
+
   // the number of blocks for each partitioning column
-  protected List<Integer> partitionCounts = new ArrayList<>();    
+  protected List<Integer> partitionCounts = new ArrayList<>();
 
   protected boolean overwrite = false;
 
@@ -51,6 +53,7 @@ public class CreateTableAsSelectQuery extends CreateTableQuery {
   }
 
   public CreateTableAsSelectQuery(CreateScrambledTableQuery query) {
+    this.originalQuery = query;
     this.schemaName = query.schemaName;
     this.tableName = query.tableName;
     this.partitionColumns.addAll(query.partitionColumns);
@@ -63,7 +66,7 @@ public class CreateTableAsSelectQuery extends CreateTableQuery {
   public void addPartitionColumn(String column) {
     partitionColumns.add(column);
   }
-  
+
   public void addPartitionCount(int count) {
     partitionCounts.add(count);
   }
@@ -75,7 +78,7 @@ public class CreateTableAsSelectQuery extends CreateTableQuery {
   public List<String> getPartitionColumns() {
     return partitionColumns;
   }
-  
+
   public List<Integer> getPartitionCounts() {
     return partitionCounts;
   }
@@ -86,6 +89,10 @@ public class CreateTableAsSelectQuery extends CreateTableQuery {
 
   public void setOverwrite(boolean overwrite) {
     this.overwrite = overwrite;
+  }
+
+  public CreateTableQuery getOriginalQuery() {
+    return originalQuery;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
+++ b/src/main/java/org/verdictdb/metastore/ScrambleMetaStore.java
@@ -332,6 +332,7 @@ public class ScrambleMetaStore extends VerdictMetaStore {
       DbmsQueryResult result = conn.execute(sql);
 
       Set<Pair<BaseTable, BaseTable>> deletedSet = new HashSet<>();
+      Set<Pair<BaseTable, BaseTable>> addedSet = new HashSet<>();
 
       while (result.next()) {
         String originalSchema = result.getString(0);
@@ -349,8 +350,13 @@ public class ScrambleMetaStore extends VerdictMetaStore {
         if (deletedSet.contains(pair)) {
           continue;
         }
+        if (addedSet.contains(pair)) {
+          continue;
+        }
         ScrambleMeta meta = ScrambleMeta.fromJsonString(jsonString);
         retrieved.addScrambleMeta(meta);
+
+        addedSet.add(pair);
       }
     } catch (VerdictDBException e) {
       e.printStackTrace();

--- a/src/main/java/org/verdictdb/sqlsyntax/PrestoHiveSyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/PrestoHiveSyntax.java
@@ -16,5 +16,26 @@
 
 package org.verdictdb.sqlsyntax;
 
+import com.google.common.base.Joiner;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /** Created by Dong Young Yoon on 10/12/18. */
-public class PrestoHiveSyntax extends PrestoSyntax {}
+public class PrestoHiveSyntax extends PrestoSyntax {
+  @Override
+  public boolean doesSupportTablePartitioning() {
+    return true;
+  }
+
+  @Override
+  public String getPartitionByInCreateTable(
+      List<String> partitionColumns, List<Integer> partitionCounts) {
+    List<String> quotedColumns = new ArrayList<>();
+    for (String column : partitionColumns) {
+      quotedColumns.add("'" + column + "'");
+    }
+
+    return "partitioned_by = ARRAY[" + Joiner.on(",").join(quotedColumns) + "]";
+  }
+}

--- a/src/main/java/org/verdictdb/sqlwriter/CreateTableToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/CreateTableToSql.java
@@ -260,9 +260,6 @@ public class CreateTableToSql {
     SelectQueryToSql selectWriter = new SelectQueryToSql(syntax);
     String selectSql = selectWriter.toSql(select);
 
-    sql.append("SELECT * FROM (");
-    sql.append(selectSql);
-    sql.append(") tmp ");
     if (query.getOriginalQuery() != null
         && query.getOriginalQuery() instanceof CreateScrambledTableQuery) {
       CreateScrambledTableQuery q = (CreateScrambledTableQuery) query.getOriginalQuery();
@@ -270,8 +267,15 @@ public class CreateTableToSql {
       if (relativeSize < 1.0) {
         int maxBlockCount = (int) Math.ceil((double) q.getBlockCount() * relativeSize);
         if (maxBlockCount == 0) maxBlockCount = 1;
+        sql.append("SELECT * FROM (");
+        sql.append(selectSql);
+        sql.append(") tmp ");
         sql.append(String.format("WHERE %s < %d", q.getBlockColumnName(), maxBlockCount));
+      } else {
+        sql.append(selectSql);
       }
+    } else {
+      sql.append(selectSql);
     }
 
     return sql.toString();

--- a/src/main/java/org/verdictdb/sqlwriter/CreateTableToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/CreateTableToSql.java
@@ -33,7 +33,6 @@ import org.verdictdb.sqlsyntax.HiveSyntax;
 import org.verdictdb.sqlsyntax.ImpalaSyntax;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
 import org.verdictdb.sqlsyntax.PrestoHiveSyntax;
-import org.verdictdb.sqlsyntax.PrestoSyntax;
 import org.verdictdb.sqlsyntax.SparkSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 
@@ -228,29 +227,30 @@ public class CreateTableToSql {
       sql.append("using parquet ");
     }
 
-    if (syntax instanceof PrestoSyntax) {
+    if (syntax instanceof PrestoHiveSyntax) {
       sql.append("WITH (");
-    }
-
-    // partitions
-    if (syntax.doesSupportTablePartitioning() && query.getPartitionColumns().size() > 0) {
-      sql.append(
-          syntax.getPartitionByInCreateTable(
-              query.getPartitionColumns(), query.getPartitionCounts()));
-      sql.append(" ");
+      sql.append("format = 'orc'");
+      if (syntax.doesSupportTablePartitioning() && query.getPartitionColumns().size() > 0) {
+        sql.append(", ");
+        sql.append(
+            syntax.getPartitionByInCreateTable(
+                query.getPartitionColumns(), query.getPartitionCounts()));
+        sql.append(" ");
+      }
+      sql.append(") ");
+    } else {
+      // partitions
+      if (syntax.doesSupportTablePartitioning() && query.getPartitionColumns().size() > 0) {
+        sql.append(
+            syntax.getPartitionByInCreateTable(
+                query.getPartitionColumns(), query.getPartitionCounts()));
+        sql.append(" ");
+      }
     }
 
     // parquet format
     if (syntax instanceof HiveSyntax || syntax instanceof ImpalaSyntax) {
       sql.append("stored as parquet ");
-    }
-
-    if (syntax instanceof PrestoHiveSyntax) {
-      sql.append("format = 'orc'");
-    }
-
-    if (syntax instanceof PrestoSyntax) {
-      sql.append(") ");
     }
 
     // select
@@ -259,7 +259,20 @@ public class CreateTableToSql {
     }
     SelectQueryToSql selectWriter = new SelectQueryToSql(syntax);
     String selectSql = selectWriter.toSql(select);
+
+    sql.append("SELECT * FROM (");
     sql.append(selectSql);
+    sql.append(") tmp ");
+    if (query.getOriginalQuery() != null
+        && query.getOriginalQuery() instanceof CreateScrambledTableQuery) {
+      CreateScrambledTableQuery q = (CreateScrambledTableQuery) query.getOriginalQuery();
+      double relativeSize = q.getRelativeSize();
+      if (relativeSize < 1.0) {
+        int maxBlockCount = (int) Math.ceil((double) q.getBlockCount() * relativeSize);
+        if (maxBlockCount == 0) maxBlockCount = 1;
+        sql.append(String.format("WHERE %s < %d", q.getBlockColumnName(), maxBlockCount));
+      }
+    }
 
     return sql.toString();
   }

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -124,7 +124,8 @@ public class RedshiftScrambleManipulationTest {
     vc.createStatement()
         .execute(
             String.format(
-                "CREATE SCRAMBLE %s.orders_scramble2 FROM %s.orders", SCHEMA_NAME, SCHEMA_NAME));
+                "CREATE SCRAMBLE %s.orders_scramble2 FROM %s.orders SIZE 0.1 BLOCKSIZE 50",
+                SCHEMA_NAME, SCHEMA_NAME));
     vc.createStatement()
         .execute(
             String.format(
@@ -137,6 +138,18 @@ public class RedshiftScrambleManipulationTest {
       assertEquals(rs.getString(2), "orders");
       assertEquals(rs.getString(3), SCHEMA_NAME);
       assertTrue(rs.getString(4).startsWith("orders_scramble"));
+    }
+
+    ResultSet rs1 =
+        conn.createStatement()
+            .executeQuery(String.format("SELECT COUNT(*) FROM %s.orders_scramble1", SCHEMA_NAME));
+    ResultSet rs2 =
+        conn.createStatement()
+            .executeQuery(String.format("SELECT COUNT(*) FROM %s.orders_scramble2", SCHEMA_NAME));
+
+    if (rs1.next() && rs2.next()) {
+      assertEquals(rs1.getLong(1), 258);
+      assertTrue(rs2.getLong(1) < 100);
     }
   }
 


### PR DESCRIPTION
1. Enable partitioning for temporary tables with Presto + Hive
2. Add support for partial scramble table with SIZE (e.g., CREATE SCRAMBLE A FROM B SIZE 0.2)
3. Add support for specifying block size for scramble table with BLOCKSIZE (e.g., CREATE SCRAMBLE A FROM B BLOCKSIZE 10000)
4. Fix a bug ScrambleMetaStore retrieves the oldest meta information for scrambles instead of most recent one

I will update the documentation once this gets approved..

@pyongjoo I also verified that nodes get executed sequentially in order of their block numbers. Adding a delay between `runOnThreads()` gave a worse performance so I did not touch them.