### PR TITLE
Occasional scaling error fix

### DIFF
--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -217,42 +217,40 @@ public class ExecutableNodeRunner implements Runnable {
   }
 
   private void runDependents() {
-    synchronized (this) {
-      if (doesThisNodeContainAsyncAggExecutionNode()) {
-        int maxNumberOfRunningNode = getMaxNumberOfRunningNode();
-        int currentlyRunningOrCompleteNodeCount = childRunners.size();
+    if (doesThisNodeContainAsyncAggExecutionNode()) {
+      int maxNumberOfRunningNode = getMaxNumberOfRunningNode();
+      int currentlyRunningOrCompleteNodeCount = childRunners.size();
 
-        // check the number of currently running nodes
-        int runningChildCount = 0;
-        for (ExecutableNodeRunner r : childRunners) {
-          if (r.getStatus() == NodeRunningStatus.running) {
-            runningChildCount++;
-          }
+      // check the number of currently running nodes
+      int runningChildCount = 0;
+      for (ExecutableNodeRunner r : childRunners) {
+        if (r.getStatus() == NodeRunningStatus.running) {
+          runningChildCount++;
         }
+      }
 
-        // maintain the number of running nodes to a certain number
-        List<ExecutableNodeBase> childNodes = ((ExecutableNodeBase) node).getSources();
-        int moreToRun = Math.min(
-            maxNumberOfRunningNode - runningChildCount,
-            ((ExecutableNodeBase) node).getSourceCount() - currentlyRunningOrCompleteNodeCount);
-        for (int i = currentlyRunningOrCompleteNodeCount;
-             i < currentlyRunningOrCompleteNodeCount + moreToRun; i++) {
-          ExecutableNodeBase child = childNodes.get(i);
+      // maintain the number of running nodes to a certain number
+      List<ExecutableNodeBase> childNodes = ((ExecutableNodeBase) node).getSources();
+      int moreToRun = Math.min(
+          maxNumberOfRunningNode - runningChildCount,
+          ((ExecutableNodeBase) node).getSourceCount() - currentlyRunningOrCompleteNodeCount);
+      for (int i = currentlyRunningOrCompleteNodeCount;
+          i < currentlyRunningOrCompleteNodeCount + moreToRun; i++) {
+        ExecutableNodeBase child = childNodes.get(i);
 
-          ExecutableNodeRunner runner = child.getRegisteredRunner();
-          boolean started = runner.runThisAndDependents();
-          if (started) {
-            childRunners.add(runner);
-          }
+        ExecutableNodeRunner runner = child.getRegisteredRunner();
+        boolean started = runner.runThisAndDependents();
+        if (started) {
+          childRunners.add(runner);
         }
-      } else {
-        // by default, run every child
-        for (ExecutableNodeBase child : ((ExecutableNodeBase) node).getSources()) {
-          ExecutableNodeRunner runner = child.getRegisteredRunner();
-          boolean started = runner.runThisAndDependents();
-          if (started) {
-            childRunners.add(runner);
-          }
+      }
+    } else {
+      // by default, run every child
+      for (ExecutableNodeBase child : ((ExecutableNodeBase) node).getSources()) {
+        ExecutableNodeRunner runner = child.getRegisteredRunner();
+        boolean started = runner.runThisAndDependents();
+        if (started) {
+          childRunners.add(runner);
         }
       }
     }

--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -262,7 +262,7 @@ public class ExecutableNodeRunner implements Runnable {
    * A single run of this method consumes all combinations of the tokens in the queue.
    */
   @Override
-  public void run() {
+  public synchronized void run() {
     //    String nodeType = node.getClass().getSimpleName();
     //    int nodeGroupId = ((ExecutableNodeBase) node).getGroupId();
 
@@ -422,7 +422,7 @@ public class ExecutableNodeRunner implements Runnable {
    * @return Information for the upstream nodes.
    * @throws VerdictDBException
    */
-  public synchronized ExecutionInfoToken execute(List<ExecutionInfoToken> tokens) 
+  public ExecutionInfoToken execute(List<ExecutionInfoToken> tokens) 
       throws VerdictDBException {
     if (tokens.size() > 0 && tokens.get(0).isStatusToken()) {
       return null;

--- a/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutableNodeRunner.java
@@ -414,7 +414,16 @@ public class ExecutableNodeRunner implements Runnable {
     }
   }
 
-  public ExecutionInfoToken execute(List<ExecutionInfoToken> tokens) throws VerdictDBException {
+  /**
+   * Execute the associated node. This method is synchronized on object level, assuming that
+   * every node has its own associated ExecutableNodeRunner, which is actually the case.
+   * 
+   * @param tokens Contains information from the downstream nodes.
+   * @return Information for the upstream nodes.
+   * @throws VerdictDBException
+   */
+  public synchronized ExecutionInfoToken execute(List<ExecutionInfoToken> tokens) 
+      throws VerdictDBException {
     if (tokens.size() > 0 && tokens.get(0).isStatusToken()) {
       return null;
     }

--- a/src/main/java/org/verdictdb/core/execplan/ExecutablePlanRunner.java
+++ b/src/main/java/org/verdictdb/core/execplan/ExecutablePlanRunner.java
@@ -101,6 +101,9 @@ public class ExecutablePlanRunner {
     for (int gid : groupIds) {
       List<ExecutableNode> nodes = plan.getNodesInGroup(gid);
       for (ExecutableNode n : nodes) {
+        // It is critically that each node is associated with a separate ExecutableNodeRunner.
+        // The execution of the same ExecutableNodeRunner instance is serialized.
+        // See ExecutableNodeRunner.execute() method.
         nodeRunners.add(new ExecutableNodeRunner(conn, n));
       }
     }

--- a/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
@@ -193,27 +193,27 @@ public class SelectAsyncAggExecutionNode extends AsyncAggExecutionNode {
     // Addition check that the query is a query contains Asterisk column that without asyncAggExecutionNode.
     // For instance, query like 'select * from lineitem'. In that case, all the values of isAggregate field
     // are false.
-    if (token.containsKey("queryResult")) {
-      DbmsQueryResult queryResult = (DbmsQueryResult) token.getValue("queryResult");
-      if (queryResult.getColumnCount() != queryResult.getMetaData().isAggregate.size()) {
-        List<Boolean> isAggregate = new ArrayList<>();
-        for (int i = 0; i < queryResult.getColumnCount(); i++) {
-          isAggregate.add(false);
-        }
-        for (int i = 0; i < queryResult.getMetaData().isAggregate.size(); i++) {
-          // If it is not asterisk column, we will find the index of the column in queryResult.
-          if (!selectQueryColumnAlias.get(i).equals(asteriskAlias)) {
-            int idx = 0;
-            // Get the index of the alias name in the columnName field of the queryResult.
-            while (!selectQueryColumnAlias.get(i).equals(queryResult.getColumnName(idx))) {
-              idx++;
-            }
-            isAggregate.set(idx, queryResult.getMetaData().isAggregate.get(i));
-          }
-        }
-        queryResult.getMetaData().isAggregate = isAggregate;
-      }
-    }
+//    if (token.containsKey("queryResult")) {
+//      DbmsQueryResult queryResult = (DbmsQueryResult) token.getValue("queryResult");
+//      if (queryResult.getColumnCount() != queryResult.getMetaData().isAggregate.size()) {
+//        List<Boolean> isAggregate = new ArrayList<>();
+//        for (int i = 0; i < queryResult.getColumnCount(); i++) {
+//          isAggregate.add(false);
+//        }
+//        for (int i = 0; i < queryResult.getMetaData().isAggregate.size(); i++) {
+//          // If it is not asterisk column, we will find the index of the column in queryResult.
+//          if (!selectQueryColumnAlias.get(i).equals(asteriskAlias)) {
+//            int idx = 0;
+//            // Get the index of the alias name in the columnName field of the queryResult.
+//            while (!selectQueryColumnAlias.get(i).equals(queryResult.getColumnName(idx))) {
+//              idx++;
+//            }
+//            isAggregate.set(idx, queryResult.getMetaData().isAggregate.get(i));
+//          }
+//        }
+//        queryResult.getMetaData().isAggregate = isAggregate;
+//      }
+//    }
     return token;
   }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -35,7 +35,7 @@
 
     <!--<statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />-->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <logger name="org.verdictdb" level="debug">
+    <logger name="org.verdictdb" level="trace">
         <appender-ref ref="VERDICTDB_STDOUT"/>
     </logger>
     <root level="ERROR">


### PR DESCRIPTION
I placed an objective on ExecutableNodeRunner.run() for serialized executions. This seems to be helpful when multiple results are passed concurrently from individual aggregations.