### PR TITLE
Setting innodb_buffer_pool_size to 2GB for MySQL in CircleCI Jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
+      command: mysqld --innodb_buffer_pool_size=2G
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,11 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
+      command: mysqld --innodb_buffer_pool_size=2G
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     - image: postgres:10
-      command: mysqld --innodb_buffer_pool_size=1G
       environment:
         POSTGRES_DB: test
         POSTGRES_USER: postgres
@@ -163,7 +163,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=1G
+      command: mysqld --innodb_buffer_pool_size=2G
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     - image: postgres:10
+      command: mysqld --innodb_buffer_pool_size=1G
       environment:
         POSTGRES_DB: test
         POSTGRES_USER: postgres
@@ -162,6 +163,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
+      command: mysqld --innodb_buffer_pool_size=1G
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"


### PR DESCRIPTION
I have observed that a CircleCi job fails occasionally waiting for MySql tests to finish (e.g., CircleCI job [link1](https://circleci.com/gh/mozafari/verdictdb/3286), [link2](https://circleci.com/gh/mozafari/verdictdb/3267))

I think allocating a higher value (=2GB, default is 128MB) for `innodb_buffer_pool_size` may mitigate this issue and a few test runs from this PR seemed to help.