### PR TITLE
Fix nullptr exception when aggregate column contains null value

### DIFF
--- a/src/main/java/org/verdictdb/coordinator/QueryResultAccuracyEstimatorFromDifference.java
+++ b/src/main/java/org/verdictdb/coordinator/QueryResultAccuracyEstimatorFromDifference.java
@@ -216,12 +216,23 @@ public class QueryResultAccuracyEstimatorFromDifference extends QueryResultAccur
     return isValueConverged;
   }
 
+  /**
+   *
+   * @return True if and only query contains only count or count distinct and doesn't contain group by
+   */
   public boolean checkIfQueryCountOnly() {
+    if (!originalQuery.getGroupby().isEmpty()) {
+      return false;
+    }
     for (SelectItem sel:this.originalQuery.getSelectList()) {
       if (sel instanceof AliasedColumn) {
         UnnamedColumn col = ((AliasedColumn) sel).getColumn();
-        if (!(col instanceof ColumnOp && ((ColumnOp) col).getOpType().equals("count"))) {
+        if (!(col instanceof ColumnOp)) {
           return false;
+        } else {
+          if (!(((ColumnOp)col).isCountDistinctAggregate() || ((ColumnOp)col).isCountAggregate())) {
+            return false;
+          }
         }
       } else {
         return false;

--- a/src/main/java/org/verdictdb/coordinator/QueryResultAccuracyEstimatorFromDifference.java
+++ b/src/main/java/org/verdictdb/coordinator/QueryResultAccuracyEstimatorFromDifference.java
@@ -150,7 +150,12 @@ public class QueryResultAccuracyEstimatorFromDifference extends QueryResultAccur
       for (int i = 0; i < currentAnswer.getColumnCount(); i++) {
         if (nongroupingColumnIndxes.contains(i)) {
 //        if (currentAnswer.getMetaData().isAggregate.get(i)) {
-          aggregateValues.add(currentAnswer.getValue(i));
+          // if the aggregate value is null value, we just let it to be 0.
+          if (currentAnswer.getValue(i) == null) {
+            aggregateValues.add(0);
+          } else {
+            aggregateValues.add(currentAnswer.getValue(i));
+          }
         } else {
           groupValues.add(currentAnswer.getValue(i));
         }

--- a/src/main/java/org/verdictdb/core/sqlobject/ColumnOp.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/ColumnOp.java
@@ -419,7 +419,12 @@ public class ColumnOp implements UnnamedColumn, SelectItem {
     Set<String> ops = new HashSet<>(Arrays.asList("max"));
     return doesContainOpIn(ops);
   }
-  
+
+  public boolean isCountAggregate() {
+    Set<String> ops = new HashSet<>(Arrays.asList("count"));
+    return doesContainOpIn(ops);
+  }
+
   public boolean isCountDistinctAggregate() {
     Set<String> ops = new HashSet<>(Arrays.asList("countdistinct", "approx_distinct"));
     return doesContainOpIn(ops);

--- a/src/test/java/org/verdictdb/VerdictDBSumNullValueTest.java
+++ b/src/test/java/org/verdictdb/VerdictDBSumNullValueTest.java
@@ -8,7 +8,6 @@ import org.verdictdb.commons.VerdictOption;
 import org.verdictdb.connection.CachedDbmsConnection;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
-import org.verdictdb.connection.SparkConnection;
 import org.verdictdb.coordinator.*;
 import org.verdictdb.core.resulthandler.ExecutionResultReader;
 import org.verdictdb.core.scrambling.ScrambleMeta;
@@ -56,7 +55,7 @@ public class VerdictDBSumNullValueTest {
 
   private static final String MYSQL_UESR = "root";
 
-  private static final String MYSQL_PASSWORD = "zhongshucheng123";
+  private static final String MYSQL_PASSWORD = "";
 
   @BeforeClass
   public static void setupMySqlDatabase() throws SQLException, VerdictDBException {

--- a/src/test/java/org/verdictdb/VerdictDBSumNullValueTest.java
+++ b/src/test/java/org/verdictdb/VerdictDBSumNullValueTest.java
@@ -1,0 +1,107 @@
+package org.verdictdb;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.verdictdb.commons.DatabaseConnectionHelpers;
+import org.verdictdb.commons.VerdictOption;
+import org.verdictdb.connection.DbmsConnection;
+import org.verdictdb.connection.DbmsQueryResult;
+import org.verdictdb.connection.SparkConnection;
+import org.verdictdb.coordinator.*;
+import org.verdictdb.core.resulthandler.ExecutionResultReader;
+import org.verdictdb.core.scrambling.ScrambleMeta;
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+import org.verdictdb.core.sqlobject.AbstractRelation;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.exception.VerdictDBException;
+import org.verdictdb.sqlreader.NonValidatingSQLParser;
+import org.verdictdb.sqlreader.RelationStandardizer;
+import org.verdictdb.sqlsyntax.MysqlSyntax;
+import org.verdictdb.sqlwriter.SelectQueryToSql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * This test is to check NULL value is returned when no row is selected by sum().
+ */
+
+public class VerdictDBSumNullValueTest {
+
+  static ScrambleMetaSet meta = new ScrambleMetaSet();
+
+  static final String TEST_SCHEMA =
+      "spark_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
+
+  static DbmsConnection conn;
+
+  static SparkSession spark;
+
+  @BeforeClass
+  public static void setupSpark() throws VerdictDBException {
+    String appname = "sparkTest";
+    spark = DatabaseConnectionHelpers.setupSpark(appname, TEST_SCHEMA);
+    conn = new SparkConnection(spark);
+
+    // Create Scramble table
+    conn.execute(String.format("DROP TABLE IF EXISTS `%s`.`lineitem_scrambled`", TEST_SCHEMA));
+    conn.execute(String.format("DROP TABLE IF EXISTS `%s`.`orders_scrambled`", TEST_SCHEMA));
+
+    ScramblingCoordinator scrambler =
+        new ScramblingCoordinator(conn, TEST_SCHEMA, TEST_SCHEMA, (long) 200);
+    ScrambleMeta meta1 =
+        scrambler.scramble(TEST_SCHEMA, "lineitem", TEST_SCHEMA, "lineitem_scrambled", "uniform");
+    ScrambleMeta meta2 =
+        scrambler.scramble(TEST_SCHEMA, "orders", TEST_SCHEMA, "orders_scrambled", "uniform");
+    meta.addScrambleMeta(meta1);
+    meta.addScrambleMeta(meta2);
+
+
+  }
+
+  @Before
+  public void setupSchema() {
+    spark.sql(
+        String.format(
+            "drop schema if exists `%s` cascade", VerdictOption.getDefaultTempSchemaName()));
+    spark.sql(
+        String.format(
+            "create schema if not exists `%s`", VerdictOption.getDefaultTempSchemaName()));
+  }
+
+  @Test
+  public void test() throws VerdictDBException {
+    // This query doesn't select any rows.
+    String sql = String.format(
+        "select sum(l_extendedprice) from " +
+            "%s.lineitem, %s.customer, %s.orders " +
+            "where c_mktsegment='AAAAAA' and c_custkey=o_custkey and o_orderkey=l_orderkey",
+        TEST_SCHEMA, TEST_SCHEMA, TEST_SCHEMA);
+
+    DbmsConnection dbmsconn = new SparkConnection(spark);
+    dbmsconn.setDefaultSchema(TEST_SCHEMA);
+    SelectQueryCoordinator coordinator = new SelectQueryCoordinator(dbmsconn);
+
+    coordinator.setScrambleMetaSet(meta);
+    ExecutionResultReader reader = coordinator.process(sql);
+    VerdictResultStream stream = new VerdictResultStreamFromExecutionResultReader(reader);
+
+    try {
+      while (stream.hasNext()) {
+        VerdictSingleResult rs = stream.next();
+        rs.next();
+        assertNull(rs.getValue(0));
+        assertEquals(0, rs.getDouble(0), 0);
+        assertEquals(0, rs.getInt(0));
+      }
+    } catch (RuntimeException e) {
+      throw e;
+    }
+
+  }
+}


### PR DESCRIPTION
Related issue #321.

The problem is in the execution of selectAsyncAggNode, where H2 jdbc driver will return NULL value if no rows are selected for aggregating. I think adding the check inside QueryResultAccuracyEstimatorFromDifference is enough, since DbmsQueryResult will interpret NULL as 0 automatically.