### PR TITLE
Add support for 'scramble appending' (issue #302)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --log_output=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -164,7 +164,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --log_output=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
       MAVEN_OPTS: -Xmx3200m
     steps:
     - run: apt-get update; apt-get install -y git
+    - setup_remote_docker
     - checkout
 
     # Set up maven dependencies
@@ -179,6 +180,7 @@ jobs:
       MAVEN_OPTS: -Xmx3200m
     steps:
     - run: apt-get update; apt-get install -y git
+    - setup_remote_docker
     - checkout
 
     # Set up maven dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -164,7 +164,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --log_output=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -164,7 +164,7 @@ jobs:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
     - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --log_output=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
       environment:
         MYSQL_DATABASE: test
         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
@@ -12,6 +12,7 @@ SCRAMBLE:                        S C R A M B L E;
 SCRAMBLES:                       S C R A M B L E S;
 STREAM:                          S T R E A M;
 GET:                             G E T;
+APPEND:                          A P P E N D;
 
 
 

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -68,6 +68,7 @@ verdict_statement
 //WITH SIZE size=(FLOAT | DECIMAL) '%' (STORE poission_cols=DECIMAL POISSON COLUMNS)? (STRATIFIED BY column_name (',' column_name)*)?
 create_scramble_statement
     : CREATE SCRAMBLE (IF NOT EXISTS)? scrambled_table=table_name FROM original_table=table_name
+      (WHERE where=search_condition)?
       (METHOD method=scrambling_method_name)?
       ((HASHCOLUMN | ON) hash_column=column_name)? 
       ((SIZE | RATIO) percent=FLOAT)?

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -76,7 +76,7 @@ create_scramble_statement
     ;
 
 insert_scramble_statement
-	: INSERT SCRAMBLE scrambled_table=table_name WHERE where=search_condition
+	: (APPEND|INSERT) SCRAMBLE scrambled_table=table_name WHERE where=search_condition
 	;
 
 scrambling_method_name

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -52,6 +52,7 @@ verdict_statement
     : select_statement
     | stream_select_statement
     | create_scramble_statement
+    | insert_scramble_statement
     | drop_scramble_statement
     | drop_all_scrambles_statement
     | show_scrambles_statement
@@ -72,6 +73,10 @@ create_scramble_statement
       ((SIZE | RATIO) percent=FLOAT)?
       (BLOCKSIZE blocksize=DECIMAL)?
     ;
+
+insert_scramble_statement
+	: INSERT SCRAMBLE scrambled_table=table_name WHERE where=search_condition
+	;
 
 scrambling_method_name
     : config_value

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -464,7 +464,7 @@ public class ExecutionContext {
             RelationGen g = new RelationGen();
             CondGen cond = new CondGen();
             BaseTable scrambleTable = (BaseTable) g.visit(ctx.scrambled_table);
-            UnnamedColumn where = (UnnamedColumn) cond.visit(ctx.where);
+            UnnamedColumn where = cond.visit(ctx.where);
 
             scrambleQuery.setNewSchema(scrambleTable.getSchemaName());
             scrambleQuery.setNewTable(scrambleTable.getTableName());
@@ -498,6 +498,8 @@ public class ExecutionContext {
                     : Long.parseLong(ctx.blocksize.getText());
             String hashColumnName =
                 (ctx.hash_column == null) ? null : stripQuote(ctx.hash_column.getText());
+            CondGen cond = new CondGen();
+            UnnamedColumn where = (ctx.where == null ? null : cond.visit(ctx.where));
 
             CreateScrambleQuery query =
                 new CreateScrambleQuery(
@@ -509,7 +511,7 @@ public class ExecutionContext {
                     percent,
                     blocksize,
                     hashColumnName,
-                    null);
+                    where);
             if (ctx.IF() != null) query.setIfNotExists(true);
             return query;
           }

--- a/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
@@ -65,7 +65,7 @@ import java.util.Set;
 //
 // 4. blockSize = scrambleTableSize / actualBlockCount
 //
-// CREATE TABLE scrmabledTable AS
+// CREATE TABLE scrambledTable AS
 // SELECT * FROM ( SELECT *, rand() * blockCount as verdictdbblock FROM originalTable) t
 // WHERE verdictdbblock < actualBlockCount
 //

--- a/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
@@ -40,6 +40,7 @@ import org.verdictdb.core.sqlobject.DropTableQuery;
 import org.verdictdb.core.sqlobject.InsertIntoSelectQuery;
 import org.verdictdb.core.sqlobject.SelectItem;
 import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
 import org.verdictdb.sqlwriter.QueryToSql;
@@ -202,6 +203,7 @@ public class ScramblingCoordinator {
             methodName,
             primaryColumn,
             1.0,
+            null,
             customOptions);
     return meta;
   }
@@ -304,6 +306,7 @@ public class ScramblingCoordinator {
             methodName,
             primaryColumn,
             relativeSize,
+            query.getWhere(),
             customOptions);
 
     return meta;
@@ -327,6 +330,7 @@ public class ScramblingCoordinator {
             methodName,
             primaryColumn,
             1.0,
+            null,
             customOptions);
     return meta;
   }
@@ -339,6 +343,7 @@ public class ScramblingCoordinator {
    * @param methodName Either 'uniform' or 'hash'
    * @param primaryColumn Passes hashcolumn for hash sampling.
    * @param relativeSize The ratio of a scramble in comparison to the original table.
+   * @param where condition to be used for creating a scramble
    * @param customOptions
    * @return
    * @throws VerdictDBException
@@ -352,6 +357,7 @@ public class ScramblingCoordinator {
       String methodName,
       String primaryColumn,
       double relativeSize,
+      UnnamedColumn where,
       Map<String, String> customOptions)
       throws VerdictDBException {
 
@@ -420,7 +426,7 @@ public class ScramblingCoordinator {
             originalSchema,
             originalTable,
             scramblingMethod,
-            null,
+            where,
             effectiveOptions);
     ExecutablePlanRunner.runTillEnd(conn, plan);
     log.info(String.format("Finished creating %s.%s", newSchema, newTable));

--- a/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/ScramblingCoordinator.java
@@ -18,6 +18,8 @@ package org.verdictdb.coordinator;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.connection.CachedDbmsConnection;
 import org.verdictdb.connection.ConcurrentJdbcConnection;
@@ -27,14 +29,22 @@ import org.verdictdb.core.scrambling.FastConvergeScramblingMethod;
 import org.verdictdb.core.scrambling.HashScramblingMethod;
 import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScramblingMethod;
+import org.verdictdb.core.scrambling.ScramblingMethodBase;
 import org.verdictdb.core.scrambling.ScramblingPlan;
 import org.verdictdb.core.scrambling.UniformScramblingMethod;
+import org.verdictdb.core.sqlobject.BaseColumn;
+import org.verdictdb.core.sqlobject.BaseTable;
 import org.verdictdb.core.sqlobject.CreateSchemaQuery;
 import org.verdictdb.core.sqlobject.CreateScrambleQuery;
+import org.verdictdb.core.sqlobject.DropTableQuery;
+import org.verdictdb.core.sqlobject.InsertIntoSelectQuery;
+import org.verdictdb.core.sqlobject.SelectItem;
+import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
 import org.verdictdb.sqlwriter.QueryToSql;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -197,6 +207,82 @@ public class ScramblingCoordinator {
   }
 
   // Note: this is the method currently used by the upstream interface.
+  public void appendScramble(CreateScrambleQuery query) throws VerdictDBException {
+    ScramblingMethod scramblingMethod = query.getScramblingMethod();
+    String methodName = query.getMethod();
+    String scrambleSchema = query.getNewSchema();
+    String scrambleTable = query.getNewTable();
+    String tempTable = "verdictdbtemp_" + RandomStringUtils.randomAlphanumeric(8);
+    String originalSchema = query.getOriginalSchema();
+    String originalTable = query.getOriginalTable();
+    String primaryColumn = query.getHashColumnName();
+    double relativeSize = scramblingMethod.getRelativeSize();
+
+    // overwrite options with custom options.
+    Map<String, String> effectiveOptions = new HashMap<>();
+    for (Entry<String, String> o : options.entrySet()) {
+      effectiveOptions.put(o.getKey(), o.getValue());
+    }
+
+    // perform scrambling
+    log.info(
+        String.format(
+            "Starts to create a temporary %s scramble %s.%s from %s.%s",
+            methodName.toUpperCase(), scrambleSchema, tempTable, originalSchema, originalTable));
+    if (methodName.equalsIgnoreCase("hash")) {
+      log.info(String.format("Method: %s on %s", methodName.toUpperCase(), primaryColumn));
+    } else {
+      log.info(String.format("Method: %s", methodName.toUpperCase()));
+    }
+    log.info(
+        String.format(
+            "Relative size: %.6f (or equivalently, %.4f %%)", relativeSize, relativeSize * 100));
+
+    ScramblingPlan plan =
+        ScramblingPlan.create(
+            scrambleSchema,
+            tempTable,
+            originalSchema,
+            originalTable,
+            scramblingMethod,
+            query.getWhere(),
+            effectiveOptions);
+    ExecutablePlanRunner.runTillEnd(conn, plan);
+    log.info(
+        String.format(
+            "Finished creating temporary scramble to append: %s.%s", scrambleSchema, tempTable));
+
+    List<Pair<String, String>> columns = conn.getColumns(scrambleSchema, scrambleTable);
+    List<SelectItem> selectList = new ArrayList<>();
+    for (Pair<String, String> column : columns) {
+      String columnName = column.getLeft();
+      selectList.add(new BaseColumn(columnName));
+    }
+
+    // insert temporary scramble to existing scramble
+    InsertIntoSelectQuery insertQuery = new InsertIntoSelectQuery();
+    SelectQuery selectQuery =
+        SelectQuery.create(selectList, new BaseTable(scrambleSchema, tempTable));
+    insertQuery.setSchemaName(scrambleSchema);
+    insertQuery.setTableName(scrambleTable);
+    insertQuery.setSelectQuery(selectQuery);
+
+    String sql = QueryToSql.convert(conn.getSyntax(), insertQuery);
+    conn.execute(sql);
+    log.info(
+        String.format(
+            "Appended a temporary scramble {%s.%s} to the existing scramble (%s.%s)",
+            scrambleSchema, tempTable, scrambleSchema, scrambleTable));
+
+    // drop temporary scramble
+    DropTableQuery dropQuery = new DropTableQuery(scrambleSchema, tempTable);
+    sql = QueryToSql.convert(conn.getSyntax(), dropQuery);
+    conn.execute(sql);
+    log.info(
+        String.format("Temporary scramble {%s.%s} has been dropped", scrambleSchema, tempTable));
+  }
+
+  // Note: this is the method currently used by the upstream interface.
   public ScrambleMeta scramble(CreateScrambleQuery query) throws VerdictDBException {
 
     String originalSchema = query.getOriginalSchema();
@@ -297,19 +383,21 @@ public class ScramblingCoordinator {
     int maxBlockCount =
         Double.valueOf(effectiveOptions.get("maxScrambleTableBlockCount")).intValue();
     ScramblingMethod scramblingMethod;
+    ScramblingMethodBase scramblingMethodBase;
     if (methodName.equalsIgnoreCase("uniform")) {
-      scramblingMethod = new UniformScramblingMethod(blockSize, maxBlockCount, relativeSize);
+      scramblingMethodBase = new UniformScramblingMethod(blockSize, maxBlockCount, relativeSize);
     } else if (methodName.equalsIgnoreCase("hash")) {
-      scramblingMethod =
+      scramblingMethodBase =
           new HashScramblingMethod(blockSize, maxBlockCount, relativeSize, primaryColumn);
     } else if (methodName.equalsIgnoreCase("FastConverge") && primaryColumn == null) {
-      scramblingMethod = new FastConvergeScramblingMethod(blockSize, scratchpadSchema.get());
+      scramblingMethodBase = new FastConvergeScramblingMethod(blockSize, scratchpadSchema.get());
     } else if (methodName.equalsIgnoreCase("FastConverge") && primaryColumn != null) {
-      scramblingMethod =
+      scramblingMethodBase =
           new FastConvergeScramblingMethod(blockSize, scratchpadSchema.get(), primaryColumn);
     } else {
       throw new VerdictDBValueException("Invalid scrambling method: " + methodName);
     }
+    scramblingMethod = scramblingMethodBase;
 
     // perform scrambling
     log.info(
@@ -327,7 +415,13 @@ public class ScramblingCoordinator {
 
     ScramblingPlan plan =
         ScramblingPlan.create(
-            newSchema, newTable, originalSchema, originalTable, scramblingMethod, effectiveOptions);
+            newSchema,
+            newTable,
+            originalSchema,
+            originalTable,
+            scramblingMethod,
+            null,
+            effectiveOptions);
     ExecutablePlanRunner.runTillEnd(conn, plan);
     log.info(String.format("Finished creating %s.%s", newSchema, newTable));
 
@@ -366,7 +460,8 @@ public class ScramblingCoordinator {
             tierCount,
             cumulativeDistribution,
             methodName,
-            primaryColumn);
+            primaryColumn,
+            scramblingMethodBase);
 
     return meta;
   }

--- a/src/main/java/org/verdictdb/core/scrambling/CreateScrambledTableNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/CreateScrambledTableNode.java
@@ -25,6 +25,7 @@ import org.verdictdb.core.querying.QueryNodeWithPlaceHolders;
 import org.verdictdb.core.sqlobject.CreateScrambledTableQuery;
 import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.SqlConvertible;
+import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 
 import java.util.ArrayList;
@@ -55,6 +56,8 @@ public class CreateScrambledTableNode extends QueryNodeWithPlaceHolders {
 
   protected ScramblingMethod method;
 
+  protected UnnamedColumn predicate;
+
   public CreateScrambledTableNode(IdCreator namer, SelectQuery query) {
     super(namer, query);
     this.namer = namer;
@@ -68,6 +71,7 @@ public class CreateScrambledTableNode extends QueryNodeWithPlaceHolders {
       ScramblingMethod method,
       String tierColumnName,
       String blockColumnName,
+      UnnamedColumn predicate,
       List<String> existingPartitionColumns,
       boolean createIfNotExists) {
     super(namer, query);
@@ -77,6 +81,7 @@ public class CreateScrambledTableNode extends QueryNodeWithPlaceHolders {
     this.method = method;
     this.tierColumnName = tierColumnName;
     this.blockColumnName = blockColumnName;
+    this.predicate = predicate;
     this.partitionColumns.addAll(existingPartitionColumns);
     this.createIfNotExists = createIfNotExists;
   }

--- a/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
@@ -121,6 +121,16 @@ public class FastConvergeScramblingMethod extends ScramblingMethodBase {
     this.type = "fastconverge";
   }
 
+  public FastConvergeScramblingMethod(
+      Map<Integer, List<Double>> probDist, String primaryColumnName) {
+    super(probDist);
+    this.type = "fastconverge";
+    this.primaryColumnName = primaryColumnName;
+    this.tier0CumulProbDist = probDist.get(0);
+    this.tier1CumulProbDist = probDist.get(1);
+    this.tier2CumulProbDist = probDist.get(2);
+  }
+
   /**
    * Computes three nodes. They compute: (1) 0.1% and 99.9% percentiles of numeric columns and the
    * total count, (for this, we compute standard deviations and estimate those percentiles based on

--- a/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/FastConvergeScramblingMethod.java
@@ -16,13 +16,7 @@
 
 package org.verdictdb.core.scrambling;
 
-import static org.verdictdb.core.scrambling.ScramblingNode.computeConditionalProbabilityDistribution;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.commons.DataTypeConverter;
 import org.verdictdb.commons.VerdictDBLogger;
@@ -50,7 +44,12 @@ import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBValueException;
 
-import com.google.common.base.Optional;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.verdictdb.core.scrambling.ScramblingNode.computeConditionalProbabilityDistribution;
 
 /**
  * Policy: 1. Tier 0: tuples containing outlier values. 2. Tier 1: tuples containing rare groups 3.
@@ -69,6 +68,10 @@ import com.google.common.base.Optional;
  * @author Yongjoo Park
  */
 public class FastConvergeScramblingMethod extends ScramblingMethodBase {
+
+  protected String type = "fastconverge";
+
+  private static final long serialVersionUID = 3640705615176207659L;
 
   double p0 = 0.5; // max portion for Tier 0; should be configured dynamically in the future
 
@@ -102,15 +105,21 @@ public class FastConvergeScramblingMethod extends ScramblingMethodBase {
 
   private static final int DEFAULT_MAX_BLOCK_COUNT = 100;
 
+  public FastConvergeScramblingMethod() {
+    super(0, 0, 0);
+  }
+
   public FastConvergeScramblingMethod(long blockSize, String scratchpadSchemaName) {
     super(blockSize, DEFAULT_MAX_BLOCK_COUNT, 1.0);
     this.scratchpadSchemaName = scratchpadSchemaName;
+    this.type = "fastconverge";
   }
 
   public FastConvergeScramblingMethod(
       long blockSize, String scratchpadSchemaName, String primaryColumnName) {
     this(blockSize, scratchpadSchemaName);
     this.primaryColumnName = Optional.of(primaryColumnName);
+    this.type = "fastconverge";
   }
 
   /**

--- a/src/main/java/org/verdictdb/core/scrambling/HashScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/HashScramblingMethod.java
@@ -1,10 +1,5 @@
 package org.verdictdb.core.scrambling;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.querying.ExecutableNodeBase;
@@ -15,8 +10,17 @@ import org.verdictdb.core.sqlobject.ColumnOp;
 import org.verdictdb.core.sqlobject.ConstantColumn;
 import org.verdictdb.core.sqlobject.UnnamedColumn;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 public class HashScramblingMethod extends ScramblingMethodBase {
-  
+
+  protected String type = "hash";
+
+  private static final long serialVersionUID = 454580102637886507L;
+
   private final String MAIN_TABLE_SOURCE_ALIAS = "t";
 
   private int totalNumberOfblocks = -1;
@@ -24,8 +28,12 @@ public class HashScramblingMethod extends ScramblingMethodBase {
   private int actualNumberOfBlocks = -1;
 
   private static final long EFFECTIVE_TABLE_SIZE_THRESHOLD = 100000;
-  
+
   private String hashColumnName;
+
+  public HashScramblingMethod() {
+    super(0, 0, 0);
+  }
 
   public HashScramblingMethod(
       long blockSize, int maxBlockCount, double relativeSize, String hashColumnName) {
@@ -74,7 +82,7 @@ public class HashScramblingMethod extends ScramblingMethodBase {
       Map<String, Object> metaData, int tier) {
     return calculateBlockCountsAndCumulativeProbabilityDistForTier(metaData, tier);
   }
-  
+
   private List<Double> calculateBlockCountsAndCumulativeProbabilityDistForTier(
       Map<String, Object> metaData, int tier) {
 
@@ -98,12 +106,12 @@ public class HashScramblingMethod extends ScramblingMethodBase {
     // This guards the case when table is empty.
     if (actualNumberOfBlocks == 0) actualNumberOfBlocks = 1;
 
-    blockSize = (long) Math.ceil(effectiveRowCount / (double) actualNumberOfBlocks);
+    long blockSizeToUse = (long) Math.ceil(effectiveRowCount / (double) actualNumberOfBlocks);
 
-    if (blockSize == 0) blockSize = 1; // just a sanity check
-    
+    if (blockSizeToUse == 0) blockSizeToUse = 1; // just a sanity check
+
     // including the ones that will be thrown away due to relative size < 1.0
-    totalNumberOfblocks = (int) Math.ceil(tableSize / (double) blockSize);    
+    totalNumberOfblocks = (int) Math.ceil(tableSize / (double) blockSizeToUse);
 
     List<Double> prob = new ArrayList<>();
     for (int i = 0; i < actualNumberOfBlocks; i++) {
@@ -129,7 +137,7 @@ public class HashScramblingMethod extends ScramblingMethodBase {
 
   @Override
   public UnnamedColumn getBlockExprForTier(int tier, Map<String, Object> metaData) {
-    
+
     calculateBlockCountsAndCumulativeProbabilityDistForTier(metaData, tier);
     BaseColumn hashColumn = new BaseColumn(MAIN_TABLE_SOURCE_ALIAS, hashColumnName);
 
@@ -137,11 +145,9 @@ public class HashScramblingMethod extends ScramblingMethodBase {
         ColumnOp.cast(
             ColumnOp.floor(
                 ColumnOp.multiply(
-                    ColumnOp.hash(hashColumn), 
-                    ConstantColumn.valueOf(totalNumberOfblocks))),
+                    ColumnOp.hash(hashColumn), ConstantColumn.valueOf(totalNumberOfblocks))),
             ConstantColumn.valueOf("int"));
 
     return blockForTierExpr;
   }
-
 }

--- a/src/main/java/org/verdictdb/core/scrambling/HashScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/HashScramblingMethod.java
@@ -100,8 +100,14 @@ public class HashScramblingMethod extends ScramblingMethodBase {
                       + "which may be too small for accurate approximation",
                   effectiveRowCount));
     }
-    actualNumberOfBlocks =
-        (int) Math.min(maxBlockCount, Math.ceil(effectiveRowCount / (double) blockSize));
+
+    // if actualNumberOfBlocks has already been calculated
+    // (i.e., scramble already exists and we are appending),
+    // then we only use those existing blocks without creating new ones.
+    if (actualNumberOfBlocks < 0) {
+      actualNumberOfBlocks =
+          (int) Math.min(maxBlockCount, Math.ceil(effectiveRowCount / (double) blockSize));
+    }
 
     // This guards the case when table is empty.
     if (actualNumberOfBlocks == 0) actualNumberOfBlocks = 1;

--- a/src/main/java/org/verdictdb/core/scrambling/ScrambleMeta.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScrambleMeta.java
@@ -18,6 +18,7 @@ package org.verdictdb.core.scrambling;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -42,6 +43,7 @@ import java.util.Map.Entry;
  *
  * @author Yongjoo Park
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({
   "schemaName",
   "tableName",
@@ -270,6 +272,10 @@ public class ScrambleMeta implements Serializable {
 
   public void setAggregationBlockCount(int aggregationBlockCount) {
     this.aggregationBlockCount = aggregationBlockCount;
+  }
+
+  public Map<Integer, List<Double>> getCumulativeDistributionForTier() {
+    return cumulativeDistributionForTier;
   }
 
   public void setCumulativeDistributionForTier(

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
@@ -44,12 +44,21 @@ public abstract class ScramblingMethodBase implements ScramblingMethod, Serializ
 
   protected final double relativeSize; // size relative to original table (0.0 ~ 1.0)
 
-  private final Map<Integer, List<Double>> storedProbDist = new HashMap<>();
+  protected Map<Integer, List<Double>> storedProbDist = new HashMap<>();
 
   public ScramblingMethodBase(long blockSize, int maxBlockCount, double relativeSize) {
     this.blockSize = blockSize;
     this.maxBlockCount = maxBlockCount;
     this.relativeSize = relativeSize;
+  }
+
+  public ScramblingMethodBase(Map<Integer, List<Double>> probDist) {
+    this.storedProbDist = probDist;
+    // uses the first tier prob. dist. to calculate the relative size for now.
+    this.relativeSize = probDist.get(0).get(probDist.get(0).size() - 1);
+    // dyoon: with stored prob. dist. these values are not necessary?
+    this.blockSize = -1;
+    this.maxBlockCount = 1;
   }
 
   long getBlockSize() {

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingMethodBase.java
@@ -16,13 +16,29 @@
 
 package org.verdictdb.core.scrambling;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class ScramblingMethodBase implements ScramblingMethod {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = UniformScramblingMethod.class, name = "uniform"),
+  @JsonSubTypes.Type(value = FastConvergeScramblingMethod.class, name = "fastconverge"),
+  @JsonSubTypes.Type(value = HashScramblingMethod.class, name = "hash")
+})
+public abstract class ScramblingMethodBase implements ScramblingMethod, Serializable {
+
+  private static final long serialVersionUID = 8767179573855372459L;
 
   protected long blockSize;
+
+  protected String type = "base";
 
   protected final int maxBlockCount;
 
@@ -47,5 +63,14 @@ public abstract class ScramblingMethodBase implements ScramblingMethod {
   @Override
   public List<Double> getStoredCumulativeProbabilityDistributionForTier(int tier) {
     return storedProbDist.get(tier);
+  }
+
+  public int getMaxBlockCount() {
+    return maxBlockCount;
+  }
+
+  @Override
+  public double getRelativeSize() {
+    return relativeSize;
   }
 }

--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
@@ -56,6 +56,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
       ScramblingMethod method,
       String tierColumnName,
       String blockColumnName,
+      UnnamedColumn predicate,
       List<String> existingPartitionColumns,
       boolean createIfNotExists) {
 
@@ -67,6 +68,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
         method,
         tierColumnName,
         blockColumnName,
+        predicate,
         existingPartitionColumns,
         createIfNotExists);
   }
@@ -87,6 +89,17 @@ public class ScramblingNode extends CreateScrambledTableNode {
       String oldSchemaName,
       String oldTableName,
       ScramblingMethod method,
+      Map<String, String> options) {
+    return create(newSchemaName, newTableName, oldSchemaName, oldTableName, method, null, options);
+  }
+
+  public static ScramblingNode create(
+      final String newSchemaName,
+      final String newTableName,
+      String oldSchemaName,
+      String oldTableName,
+      ScramblingMethod method,
+      UnnamedColumn predicate,
       Map<String, String> options) {
 
     IdCreator idCreator =
@@ -131,6 +144,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
         method,
         tierColumnName,
         blockColumnName,
+        predicate,
         existingPartitionColumns,
         createIfNotExists);
   }
@@ -244,7 +258,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
     //        SelectQuery.create(
     //            selectItems,
     //            new BaseTable(oldSchemaName, oldTableName, MAIN_TABLE_SOURCE_ALIAS_NAME));
-    SelectQuery scramblingQuery = SelectQuery.create(selectItems, tableSource);
+    SelectQuery scramblingQuery = SelectQuery.create(selectItems, tableSource, predicate);
 
     return scramblingQuery;
   }

--- a/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
@@ -93,8 +93,14 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
                       + "which may be too small for accurate approximation",
                   effectiveRowCount));
     }
-    actualNumberOfBlocks =
-        (int) Math.min(maxBlockCount, Math.ceil(effectiveRowCount / (double) blockSize));
+
+    // if actualNumberOfBlocks has already been calculated
+    // (i.e., scramble already exists and we are appending),
+    // then we only use those existing blocks without creating new ones.
+    if (actualNumberOfBlocks < 0) {
+      actualNumberOfBlocks =
+          (int) Math.min(maxBlockCount, Math.ceil(effectiveRowCount / (double) blockSize));
+    }
 
     // This guards the case when table is empty.
     if (actualNumberOfBlocks == 0) actualNumberOfBlocks = 1;

--- a/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
+++ b/src/main/java/org/verdictdb/core/scrambling/UniformScramblingMethod.java
@@ -16,11 +16,6 @@
 
 package org.verdictdb.core.scrambling;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.verdictdb.commons.VerdictDBLogger;
 import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.querying.ExecutableNodeBase;
@@ -30,7 +25,16 @@ import org.verdictdb.core.sqlobject.ColumnOp;
 import org.verdictdb.core.sqlobject.ConstantColumn;
 import org.verdictdb.core.sqlobject.UnnamedColumn;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 public class UniformScramblingMethod extends ScramblingMethodBase {
+
+  protected String type = "uniform";
+
+  private static final long serialVersionUID = 6191110854831260985L;
 
   private final String MAIN_TABLE_SOURCE_ALIAS = "t";
 
@@ -39,6 +43,10 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
   private int actualNumberOfBlocks = -1;
 
   private static final long EFFECTIVE_TABLE_SIZE_THRESHOLD = 100000;
+
+  public UniformScramblingMethod() {
+    super(0, 0, 0);
+  }
 
   public UniformScramblingMethod(long blockSize, int maxBlockCount, double relativeSize) {
     super(blockSize, maxBlockCount, relativeSize);
@@ -91,12 +99,12 @@ public class UniformScramblingMethod extends ScramblingMethodBase {
     // This guards the case when table is empty.
     if (actualNumberOfBlocks == 0) actualNumberOfBlocks = 1;
 
-    blockSize = (long) Math.ceil(effectiveRowCount / (double) actualNumberOfBlocks);
+    long blockSizeToUse = (long) Math.ceil(effectiveRowCount / (double) actualNumberOfBlocks);
 
-    if (blockSize == 0) blockSize = 1; // just a sanity check
-    
+    if (blockSizeToUse == 0) blockSizeToUse = 1; // just a sanity check
+
     // including the ones that will be thrown away due to relative size < 1.0
-    totalNumberOfblocks = (int) Math.ceil(tableSize / (double) blockSize);
+    totalNumberOfblocks = (int) Math.ceil(tableSize / (double) blockSizeToUse);
 
     List<Double> prob = new ArrayList<>();
     for (int i = 0; i < actualNumberOfBlocks; i++) {

--- a/src/main/java/org/verdictdb/core/sqlobject/CreateScrambleQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateScrambleQuery.java
@@ -16,6 +16,7 @@
 
 package org.verdictdb.core.sqlobject;
 
+import org.verdictdb.core.scrambling.ScramblingMethod;
 import org.verdictdb.exception.VerdictDBValueException;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
@@ -51,8 +52,14 @@ public class CreateScrambleQuery extends CreateTableQuery {
   /** the number of tuples for each block */
   private long blocksize;
 
-  /** The column (if present) used for hashed sampling. */
+  /** The column (if present) used for hashed sampling */
   private String hashColumnName = null;
+
+  /** the condition that will be used to create a scramble */
+  private UnnamedColumn where = null;
+
+  /** the scrambling method */
+  private ScramblingMethod scramblingMethod = null;
 
   /** Existing partition columns in the original table */
   private List<String> existingPartitionColumns;
@@ -67,7 +74,8 @@ public class CreateScrambleQuery extends CreateTableQuery {
       String method,
       double size,
       long blocksize,
-      String hashColumnName) {
+      String hashColumnName,
+      UnnamedColumn where) {
     super();
     this.newSchema = newSchema;
     this.newTable = newTable;
@@ -77,6 +85,7 @@ public class CreateScrambleQuery extends CreateTableQuery {
     this.size = size;
     this.blocksize = blocksize;
     this.hashColumnName = hashColumnName;
+    this.where = where;
   }
 
   public void setExistingPartitionColumns(List<String> existingPartitionColumns) {
@@ -185,8 +194,28 @@ public class CreateScrambleQuery extends CreateTableQuery {
     this.size = size;
   }
 
+  public long getBlocksize() {
+    return blocksize;
+  }
+
   public void setHashColumnName(String hashColumnName) {
     this.hashColumnName = hashColumnName;
+  }
+
+  public UnnamedColumn getWhere() {
+    return where;
+  }
+
+  public void setWhere(UnnamedColumn where) {
+    this.where = where;
+  }
+
+  public ScramblingMethod getScramblingMethod() {
+    return scramblingMethod;
+  }
+
+  public void setScramblingMethod(ScramblingMethod scramblingMethod) {
+    this.scramblingMethod = scramblingMethod;
   }
 
   public List<String> getExistingPartitionColumns() {

--- a/src/main/java/org/verdictdb/core/sqlobject/InsertIntoSelectQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/InsertIntoSelectQuery.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright 2018 University of Michigan
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.verdictdb.core.sqlobject;
+
+/** Created by Dong Young Yoon on 2018-12-24. */
+public class InsertIntoSelectQuery implements SqlConvertible {
+
+  private static final long serialVersionUID = -8332376574185467713L;
+
+  protected String schemaName;
+
+  protected String tableName;
+
+  protected SelectQuery selectQuery;
+
+  public String getSchemaName() {
+    return schemaName;
+  }
+
+  public void setSchemaName(String schemaName) {
+    this.schemaName = schemaName;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
+  }
+
+  public SelectQuery getSelectQuery() {
+    return selectQuery;
+  }
+
+  public void setSelectQuery(SelectQuery selectQuery) {
+    this.selectQuery = selectQuery;
+  }
+}

--- a/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
@@ -16,20 +16,19 @@
 
 package org.verdictdb.core.sqlobject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import com.google.common.base.Optional;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import com.google.common.base.Optional;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class SelectQuery extends AbstractRelation implements SqlConvertible {
-  
-//  private boolean isStandardized;
+
+  //  private boolean isStandardized;
 
   private static final long serialVersionUID = -4830209213341883527L;
 
@@ -57,7 +56,9 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
       sel.addSelectItem(c);
     }
     sel.addTableSource(relation);
-    sel.filter = Optional.of(predicate);
+    if (predicate != null) {
+      sel.filter = Optional.of(predicate);
+    }
     return sel;
   }
 
@@ -235,14 +236,14 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
   public String toString() {
     return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
   }
-  
-//  public boolean isStandardized() {
-//    return isStandardized;
-//  }
-//  
-//  public void setStandardized() {
-//    isStandardized = true;
-//  }
+
+  //  public boolean isStandardized() {
+  //    return isStandardized;
+  //  }
+  //
+  //  public void setStandardized() {
+  //    isStandardized = true;
+  //  }
 
   // deep copy the select list
   public SelectQuery selectListDeepCopy() {

--- a/src/main/java/org/verdictdb/sqlreader/ScramblingQueryGenerator.java
+++ b/src/main/java/org/verdictdb/sqlreader/ScramblingQueryGenerator.java
@@ -45,7 +45,8 @@ public class ScramblingQueryGenerator {
             method,
             size,
             blocksize,
-            hashColumnName);
+            hashColumnName,
+            null);
 
     return query;
   }

--- a/src/main/java/org/verdictdb/sqlwriter/QueryToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/QueryToSql.java
@@ -19,6 +19,7 @@ package org.verdictdb.sqlwriter;
 import org.verdictdb.core.sqlobject.CreateSchemaQuery;
 import org.verdictdb.core.sqlobject.CreateTableQuery;
 import org.verdictdb.core.sqlobject.DropTableQuery;
+import org.verdictdb.core.sqlobject.InsertIntoSelectQuery;
 import org.verdictdb.core.sqlobject.InsertValuesQuery;
 import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.SetOperationRelation;
@@ -50,6 +51,9 @@ public class QueryToSql {
     } else if (query instanceof InsertValuesQuery) {
       InsertQueryToSql tosql = new InsertQueryToSql(syntax);
       return tosql.toSql((InsertValuesQuery) query);
+    } else if (query instanceof InsertIntoSelectQuery) {
+      InsertQueryToSql tosql = new InsertQueryToSql(syntax);
+      return tosql.toSql((InsertIntoSelectQuery) query);
     } else if (query instanceof SetOperationRelation) {
       SetOperationToSql tosql = new SetOperationToSql(syntax);
       return tosql.toSql((SetOperationRelation) query);

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 public class CreateScrambleTableFromSqlTest {
 
   private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
-  //    private static final String[] targetDatabases = {"mysql"};
+  //  private static final String[] targetDatabases = {"mysql"};
 
   private static Map<String, Pair<Connection, Connection>> connections = new HashMap<>();
 

--- a/src/test/java/org/verdictdb/core/scrambling/ScrambleMetaSerializationTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/ScrambleMetaSerializationTest.java
@@ -1,14 +1,14 @@
 package org.verdictdb.core.scrambling;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.verdictdb.exception.VerdictDBValueException;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.verdictdb.exception.VerdictDBValueException;
+import static org.junit.Assert.assertEquals;
 
 public class ScrambleMetaSerializationTest {
 
@@ -48,8 +48,8 @@ public class ScrambleMetaSerializationTest {
         "{\"schemaName\":\"new_schema\",\"tableName\":\"New_Table\","
             + "\"originalSchemaName\":\"Original_Schema\",\"originalTableName\":\"origiNAL_TABLE\","
             + "\"aggregationBlockColumn\":\"verdictDBblock\",\"aggregationBlockCount\":3,"
-            + "\"tierColumn\":\"VerdictTIER\",\"numberOfTiers\":2,"
-            + "\"method\":null,\"hashColumn\":null,"
+            + "\"tierColumn\":\"VerdictTIER\",\"numberOfTiers\":2,\"method\":null,"
+            + "\"scramblingMethod\":null,\"hashColumn\":null,"
             + "\"cumulativeDistributions\":{\"0\":[0.3,0.6,1.0],\"1\":[0.2,0.5,1.0]}}";
     return jsonString;
   }

--- a/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
@@ -151,13 +151,23 @@ public class PrestoUniformScramblingQueryTest {
 
   @Test
   public void insertScrambleTest() throws SQLException {
+    int rowBefore = 0, rowAfter = 0;
+    ResultSet rs = conn.createStatement().executeQuery("SELECT COUNT(*) FROM orders_scramble");
+    if (rs.next()) {
+      rowBefore = rs.getInt(1);
+    }
     vc.createStatement()
         .execute(
             String.format(
                 "INSERT SCRAMBLE %s.orders_scramble WHERE o_totalprice < 10000",
-                SCHEMA_NAME, SCHEMA_NAME));
+                SCHEMA_NAME));
 
-    System.out.println();
+    rs = conn.createStatement().executeQuery("SELECT COUNT(*) FROM orders_scramble");
+    if (rs.next()) {
+      rowAfter = rs.getInt(1);
+    }
+
+    assertTrue(rowAfter > rowBefore);
   }
 
   @Test

--- a/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
@@ -152,17 +152,20 @@ public class PrestoUniformScramblingQueryTest {
   @Test
   public void insertScrambleTest() throws SQLException {
     int rowBefore = 0, rowAfter = 0;
-    ResultSet rs = conn.createStatement().executeQuery("SELECT COUNT(*) FROM orders_scramble");
+    ResultSet rs =
+        conn.createStatement()
+            .executeQuery(String.format("SELECT COUNT(*) FROM %s.orders_scramble", SCHEMA_NAME));
     if (rs.next()) {
       rowBefore = rs.getInt(1);
     }
     vc.createStatement()
         .execute(
             String.format(
-                "INSERT SCRAMBLE %s.orders_scramble WHERE o_totalprice < 10000",
-                SCHEMA_NAME));
+                "INSERT SCRAMBLE %s.orders_scramble WHERE o_totalprice < 10000", SCHEMA_NAME));
 
-    rs = conn.createStatement().executeQuery("SELECT COUNT(*) FROM orders_scramble");
+    rs =
+        conn.createStatement()
+            .executeQuery(String.format("SELECT COUNT(*) FROM %s.orders_scramble", SCHEMA_NAME));
     if (rs.next()) {
       rowAfter = rs.getInt(1);
     }

--- a/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
@@ -31,6 +31,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -137,15 +139,29 @@ public class PrestoUniformScramblingQueryTest {
   public void checkExistingPartitionTest() throws SQLException {
     String sql = String.format("DESCRIBE %s.orders_scramble", SCHEMA_NAME);
     ResultSet rs = conn.createStatement().executeQuery(sql);
+    Map<String, String> results = new HashMap<>();
     while (rs.next()) {
       String column = rs.getString(1);
       String extra = rs.getString(3);
+      results.put(column, extra);
       if (column.equalsIgnoreCase("o_dummy")) {
         assertTrue(extra.toLowerCase().contains("partition"));
       }
       if (column.equalsIgnoreCase("verdictdbblock")) {
         assertTrue(extra.toLowerCase().contains("partition"));
       }
+    }
+    assertTrue(results.containsKey("o_dummy"));
+    assertTrue(results.containsKey("verdictdbblock"));
+    assertTrue(results.get("o_dummy").toLowerCase().contains("partition"));
+    assertTrue(results.get("verdictdbblock").toLowerCase().contains("partition"));
+
+    // all verdictdbblock must be 0
+    sql = String.format("SELECT verdictdbblock FROM %s.orders_scramble", SCHEMA_NAME);
+    rs = conn.createStatement().executeQuery(sql);
+    while (rs.next()) {
+      int val = rs.getInt(1);
+      assertEquals(0, val);
     }
   }
 

--- a/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/PrestoUniformScramblingQueryTest.java
@@ -150,6 +150,17 @@ public class PrestoUniformScramblingQueryTest {
   }
 
   @Test
+  public void insertScrambleTest() throws SQLException {
+    vc.createStatement()
+        .execute(
+            String.format(
+                "INSERT SCRAMBLE %s.orders_scramble WHERE o_totalprice < 10000",
+                SCHEMA_NAME, SCHEMA_NAME));
+
+    System.out.println();
+  }
+
+  @Test
   public void runSimpleAggQueryTest() throws SQLException {
     String sql =
         String.format(


### PR DESCRIPTION
(Resolve #302. This PR is based on PR #326)
Added 'INSERT SCRAMBLE...' syntax to support scramble appending. 

The current implementation supports the statement of the following form:
```
INSERT SCRAMBLE <existing_scramble_table_schema>.<existing_scramble_table_name> WHERE <condition>
```

This command will append data into existing scramble using same scrambling method + source data that satisfy the given condition.

As a bonus feature, I also added conditional scramble creation like the following:
```
CREATE SCRAMBLE <scramble_table> FROM <original_table> [WHERE <condition>]
```

The current limitations for appending scramble are as follows:
1. New scramble data is appended ONLY from the original source table --> this is because current verdictdb metadata for a scramble has a mapping to its single source table. We may remove this mapping in the future, which can allow a scramble generated from multiple source tables.
1. Appending scramble will not work on scrambles built prior to this version as they do not have necessary information in their metadata to create same type of scramble on new data.
1. It is users' responsibility to make sure not to append duplicates into an existing scramble.

For current implementation, it is required to store classes implementing ScramblingMethod interface (or ScrambilngMethodBase abstract class) as a part of ScrambleMeta in JSON, thus, necessary changes are made to make them serializable (e.g., removing the use of 'Optional' in FastConvergeScramblingMethod).