### PR TITLE
throw exception when creating scramble on empty table

### DIFF
--- a/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
+++ b/src/main/java/org/verdictdb/core/scrambling/ScramblingNode.java
@@ -167,7 +167,7 @@ public class ScramblingNode extends CreateScrambledTableNode {
     return super.createQuery(tokens);
   }
 
-  SelectQuery composeQuery(Map<String, Object> metaData) {
+  SelectQuery composeQuery(Map<String, Object> metaData) throws VerdictDBException {
     // read option values
     List<UnnamedColumn> tierPredicates = method.getTierExpressions(metaData);
     int tierCount = tierPredicates.size() + 1;
@@ -234,6 +234,10 @@ public class ScramblingNode extends CreateScrambledTableNode {
         blockForTierExpr = ColumnOp.casewhen(blockForTierOperands);
       }
       */
+      // If total block size==0, it is an empty table, then throw an exception
+      if (method.getBlockCount()==0) {
+        throw new VerdictDBException("Empty table cannot be scrambled");
+      }
       if (i < tierCount - 1) {
         // "when" part in the case-when-else expression
         // for the last tier, we don't need this "when" part

--- a/src/test/java/org/verdictdb/CreateScrambleOnEmptyTableTest.java
+++ b/src/test/java/org/verdictdb/CreateScrambleOnEmptyTableTest.java
@@ -1,0 +1,102 @@
+package org.verdictdb;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.verdictdb.commons.DatabaseConnectionHelpers;
+import org.verdictdb.connection.JdbcConnection;
+import org.verdictdb.connection.StaticMetaData;
+import org.verdictdb.coordinator.ScramblingCoordinator;
+import org.verdictdb.core.scrambling.ScrambleMeta;
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+import org.verdictdb.core.scrambling.UniformScrambler;
+import org.verdictdb.exception.VerdictDBException;
+import org.verdictdb.jdbc41.VerdictConnection;
+import org.verdictdb.jdbc41.VerdictStatement;
+import org.verdictdb.sqlsyntax.H2Syntax;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.sql.Types.BIGINT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CreateScrambleOnEmptyTableTest {
+
+  static Connection conn;
+
+  static Statement stmt;
+
+  static final String schema = "tpch_emptydataset_test";
+
+  @BeforeClass
+  public static void setupH2Database() throws SQLException {
+    final String DB_CONNECTION = "jdbc:h2:mem:aggexecnodetest;DB_CLOSE_DELAY=-1";
+    final String DB_USER = "";
+    final String DB_PASSWORD = "";
+    conn = DriverManager.getConnection(DB_CONNECTION, DB_USER, DB_PASSWORD);
+
+    stmt = conn.createStatement();
+    stmt.execute(String.format("CREATE SCHEMA IF NOT EXISTS \"%s\"", schema));
+    stmt.execute(
+        "CREATE TABLE  IF NOT EXISTS \"tpch_emptydataset_test\".\"lineitem\" ( \"l_orderkey\"    INT , "
+            + "                             \"l_partkey\"     INT , "
+            + "                             \"l_suppkey\"     INT , "
+            + "                             \"l_linenumber\"  INT , "
+            + "                             \"l_quantity\"    DECIMAL(15,2) , "
+            + "                             \"l_extendedprice\"  DECIMAL(15,2) , "
+            + "                             \"l_discount\"    DECIMAL(15,2) , "
+            + "                             \"l_tax\"         DECIMAL(15,2) , "
+            + "                             \"l_returnflag\"  CHAR(1) , "
+            + "                             \"l_linestatus\"  CHAR(1) , "
+            + "                             \"l_shipdate\"    DATE , "
+            + "                             \"l_commitdate\"  DATE , "
+            + "                             \"l_receiptdate\" DATE , "
+            + "                             \"l_shipinstruct\" CHAR(25) , "
+            + "                             \"l_shipmode\"     CHAR(10) , "
+            + "                             \"l_comment\"      VARCHAR(44), "
+            + "                             \"l_dummy\" varchar(10))");
+  }
+
+  @Test
+  public void test1() throws SQLException, VerdictDBException, IOException {
+    // Create Scramble table
+    stmt.execute(
+        String.format("DROP TABLE IF EXISTS \"%s\".\"lineitem_scrambled\"", schema));
+    JdbcConnection h2conn = new JdbcConnection(conn, new H2Syntax());
+    ScramblingCoordinator scrambler =
+        new ScramblingCoordinator(h2conn, schema, schema, (long) 100);
+    // uniform scrambling
+    try {
+      scrambler.scramble(
+          schema, "lineitem", schema, "lineitem_scrambled", "uniform");
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
+
+    // hash scrambling
+    try {
+      scrambler.scramble(
+          schema, "lineitem", schema, "lineitem_hash_scrambled", "hash", "l_orderkey");
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
+  }
+
+
+}

--- a/src/test/java/org/verdictdb/core/scrambling/FastConvergeScramblingPlanTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/FastConvergeScramblingPlanTest.java
@@ -15,6 +15,8 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.core.execplan.ExecutablePlanRunner;
 import org.verdictdb.exception.VerdictDBException;
 
+import static org.junit.Assert.fail;
+
 public class FastConvergeScramblingPlanTest {
 
   private static Connection mysqlConn;
@@ -84,7 +86,15 @@ public class FastConvergeScramblingPlanTest {
 //    System.out.println(plan.getReportingNode());
 
     DbmsConnection conn = JdbcConnection.create(mysqlConn);
-    ExecutablePlanRunner.runTillEnd(conn, plan);
+
+    try {
+      ExecutablePlanRunner.runTillEnd(conn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test
@@ -113,7 +123,14 @@ public class FastConvergeScramblingPlanTest {
 //    System.out.println(plan.getReportingNode());
 
     DbmsConnection conn = JdbcConnection.create(mysqlConn);
-    ExecutablePlanRunner.runTillEnd(conn, plan);
+    try {
+      ExecutablePlanRunner.runTillEnd(conn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test

--- a/src/test/java/org/verdictdb/core/scrambling/PostgresFastConvergeScramblingPlanTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/PostgresFastConvergeScramblingPlanTest.java
@@ -16,6 +16,8 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.core.execplan.ExecutablePlanRunner;
 import org.verdictdb.exception.VerdictDBException;
 
+import static org.junit.Assert.fail;
+
 public class PostgresFastConvergeScramblingPlanTest {
 
   static Connection psqlConn;
@@ -83,7 +85,14 @@ public class PostgresFastConvergeScramblingPlanTest {
 //    System.out.println(plan.getReportingNode());
 
     DbmsConnection conn = JdbcConnection.create(psqlConn);
-    ExecutablePlanRunner.runTillEnd(conn, plan);
+    try {
+      ExecutablePlanRunner.runTillEnd(conn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test
@@ -112,7 +121,14 @@ public class PostgresFastConvergeScramblingPlanTest {
 //    System.out.println(plan.getReportingNode());
 
     DbmsConnection conn = JdbcConnection.create(psqlConn);
-    ExecutablePlanRunner.runTillEnd(conn, plan);
+    try {
+      ExecutablePlanRunner.runTillEnd(conn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test

--- a/src/test/java/org/verdictdb/core/scrambling/PostgresUniformScramblingPlanTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/PostgresUniformScramblingPlanTest.java
@@ -1,6 +1,7 @@
 package org.verdictdb.core.scrambling;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -87,7 +88,14 @@ public class PostgresUniformScramblingPlanTest {
     //    System.out.println(plan.getReportingNode());
 
     DbmsConnection dbmsConn = JdbcConnection.create(conn);
-    ExecutablePlanRunner.runTillEnd(dbmsConn, plan);
+    try {
+      ExecutablePlanRunner.runTillEnd(dbmsConn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test

--- a/src/test/java/org/verdictdb/core/scrambling/UniformScramblingPlanTest.java
+++ b/src/test/java/org/verdictdb/core/scrambling/UniformScramblingPlanTest.java
@@ -16,6 +16,8 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.core.execplan.ExecutablePlanRunner;
 import org.verdictdb.exception.VerdictDBException;
 
+import static org.junit.Assert.fail;
+
 public class UniformScramblingPlanTest {
 
   private static Connection mysqlConn;
@@ -84,7 +86,14 @@ public class UniformScramblingPlanTest {
 //    System.out.println(plan.getReportingNode());
 
     DbmsConnection conn = JdbcConnection.create(mysqlConn);
-    ExecutablePlanRunner.runTillEnd(conn, plan);
+    try {
+      ExecutablePlanRunner.runTillEnd(conn, plan);
+      fail();
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof VerdictDBException)) {
+        fail();
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Related Issue #351 
VerdictDB will throw exception if empty table is used to create scramble. I do this by checking totalBlockSize in ScrambleNode.createQuery(). If totalBlockSize==0, it is equivalent to say the table size is 0.