### PR TITLE
Disable unit tests that use private resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 general:
   branches:
     ignore:
-    - gh-pages
+      - gh-pages
 
 version: 2
 jobs:
@@ -14,80 +14,80 @@ jobs:
       image: circleci/classic:201703-01
     working_directory: ~/repo
     steps:
-    - run: java -version
-    - run: javac -version
-    - run: sudo apt-get update && sudo apt-get install -y openjdk-7-jdk
-    - run: sudo update-java-alternatives --set java-1.7.0-openjdk-amd64
-    - run: java -version
-    - run: javac -version
+      - run: java -version
+      - run: javac -version
+      - run: sudo apt-get update && sudo apt-get install -y openjdk-7-jdk
+      - run: sudo update-java-alternatives --set java-1.7.0-openjdk-amd64
+      - run: java -version
+      - run: javac -version
 
   docker-env-check:
     machine:
       image: circleci/classic:201703-01
     working_directory: ~/repo
     steps:
-    - run: docker run --rm -d --name verdictdb-impala -p 127.0.0.1:21050:21050 codingtony/impala
-    - run: pwd
-    - checkout
-    - run: echo "$(cd "$(dirname "src/test/resources")"; pwd)/$(basename "src/test/resources")"
-    - run: bash wait_until_ready.sh
+      - run: docker run --rm -d --name verdictdb-impala -p 127.0.0.1:21050:21050 codingtony/impala
+      - run: pwd
+      - checkout
+      - run: echo "$(cd "$(dirname "src/test/resources")"; pwd)/$(basename "src/test/resources")"
+      - run: bash wait_until_ready.sh
 
   build-jdk7:
     docker:
-    # specify the version you desire here
-    - image: maven:3.5.4-jdk-7-slim
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      # specify the version you desire here
+      - image: maven:3.5.4-jdk-7-slim
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.5
+        command: mysqld --innodb_buffer_pool_size=2G
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-    - run: apt-get update; apt-get install -y git
-    - checkout
-    # Set up maven dependencies
-    - restore_cache:
-        keys:
-        - verdict-dependencies-{{ checksum "pom.xml" }}
-        # fallback to using the latest cache if no exact match is found
-        - verdict-dependencies-
-    - run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
-    # - run: mvn dependency:go-offline
-    # Setup necessary test data
-    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
-    # Now build and test
-    - run:
-        name: Run unit tests
-        command: mvn -P jdk7 -B test 2> /dev/null
-        no_output_timeout: 30m
-    # Collect test metadata
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/junit
-    - store_artifacts:
-        path: ~/junit
-    - store_artifacts:
-        path: /tmp/verdictdb-debug.log
-    - save_cache:
-        paths:
-        - ~/.m2
-        key: verdict-dependencies-{{ checksum "pom.xml" }}
+      - run: apt-get update; apt-get install -y git
+      - checkout
+      # Set up maven dependencies
+      - restore_cache:
+          keys:
+            - verdict-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - verdict-dependencies-
+      - run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
+      # - run: mvn dependency:go-offline
+      # Setup necessary test data
+      #    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
+      # Now build and test
+      - run:
+          name: Run unit tests
+          command: mvn -P jdk7 -B test 2> /dev/null
+          no_output_timeout: 30m
+      # Collect test metadata
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+      - store_artifacts:
+          path: /tmp/verdictdb-debug.log
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: verdict-dependencies-{{ checksum "pom.xml" }}
 
     #update-codecov:
     #docker:
@@ -104,256 +104,256 @@ jobs:
 
   build-jdk8-update-codecov:
     docker:
-    # specify the version you desire here
-    - image: maven:3.5.4-jdk-8-slim
+      # specify the version you desire here
+      - image: maven:3.5.4-jdk-8-slim
 
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.5
+        command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-    - run: apt-get update; apt-get install -y git
-    - setup_remote_docker
-    - checkout
+      - run: apt-get update; apt-get install -y git
+      - setup_remote_docker
+      - checkout
 
-    # Set up maven dependencies
-    - restore_cache:
-        keys:
-        - verdict-dependencies-{{ checksum "pom.xml" }}
-        # fallback to using the latest cache if no exact match is found
-        # - v1-dependencies-
-    #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
-    # - run: mvn dependency:go-offline
+      # Set up maven dependencies
+      - restore_cache:
+          keys:
+            - verdict-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          # - v1-dependencies-
+      #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
+      # - run: mvn dependency:go-offline
 
-    # Setup necessary test data
-    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
-    # Now build and test
-    - run:
-        name: Run unit tests
-        command: mvn -P jdk8 -B cobertura:cobertura 2> /dev/null
-        no_output_timeout: 30m
-    # Upload codecov
-    #- run: mvn -DskipTests cobertura:cobertura
-    - run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
-    - store_artifacts:
-        path: /tmp/verdictdb-debug.log
-    - save_cache:
-        paths:
-        - ~/.m2
-        key: verdict-dependencies-{{ checksum "pom.xml" }}
-        #- run: mvn cobertura:cobertura
-        #- run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
+      # Setup necessary test data
+      #    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
+      # Now build and test
+      - run:
+          name: Run unit tests
+          command: mvn -P jdk8 -B cobertura:cobertura 2> /dev/null
+          no_output_timeout: 30m
+      # Upload codecov
+      #- run: mvn -DskipTests cobertura:cobertura
+      - run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
+      - store_artifacts:
+          path: /tmp/verdictdb-debug.log
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: verdict-dependencies-{{ checksum "pom.xml" }}
+          #- run: mvn cobertura:cobertura
+          #- run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
 
   build-jdk8:
     docker:
-    # specify the version you desire here
-    - image: maven:3.5.4-jdk-8-slim
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: mysql:5.5
-      command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      # specify the version you desire here
+      - image: maven:3.5.4-jdk-8-slim
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.5
+        command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-    - run: apt-get update; apt-get install -y git
-    - setup_remote_docker
-    - checkout
+      - run: apt-get update; apt-get install -y git
+      - setup_remote_docker
+      - checkout
 
-    # Set up maven dependencies
-    - restore_cache:
-        keys:
-        - verdict-dependencies-{{ checksum "pom.xml" }}
-        - verdict-dependencies-
-        # fallback to using the latest cache if no exact match is found
-        # - v1-dependencies-
-    - run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
-    # - run: mvn dependency:go-offline
+      # Set up maven dependencies
+      - restore_cache:
+          keys:
+            - verdict-dependencies-{{ checksum "pom.xml" }}
+            - verdict-dependencies-
+          # fallback to using the latest cache if no exact match is found
+          # - v1-dependencies-
+      - run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
+      # - run: mvn dependency:go-offline
 
-    # Setup necessary test data
-    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
-    # Now build and test
-    - run:
-        name: Run unit tests
-        command: mvn -P jdk8 -B test 2> /dev/null
-        no_output_timeout: 30m
+      # Setup necessary test data
+      #    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
+      # Now build and test
+      - run:
+          name: Run unit tests
+          command: mvn -P jdk8 -B test 2> /dev/null
+          no_output_timeout: 30m
 
-    # Check the JDBC service file correctness
-    - run: bash .circleci/check_jdbc_driver_name.sh
+      # Check the JDBC service file correctness
+      - run: bash .circleci/check_jdbc_driver_name.sh
 
-    #- run: mvn -DskipTests -P packaging package
-    # Collect test metadata
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/junit
-    - store_artifacts:
-        path: ~/junit
-    - store_artifacts:
-        path: /tmp/verdictdb-debug.log
-    - save_cache:
-        paths:
-        - ~/.m2
-        key: verdict-dependencies-{{ checksum "pom.xml" }}
-        #- run: mvn cobertura:cobertura
-        #- run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
+      #- run: mvn -DskipTests -P packaging package
+      # Collect test metadata
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+      - store_artifacts:
+          path: /tmp/verdictdb-debug.log
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: verdict-dependencies-{{ checksum "pom.xml" }}
+          #- run: mvn cobertura:cobertura
+          #- run: bash <(curl -s https://codecov.io/bash) -t 9cf48c61-07ed-4a14-9eed-f7129664ee79
 
   build-spark:
     docker:
-    # specify the version you desire here
-    - image: maven:3.5.4-jdk-8-slim
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: mysql:5.5
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      # specify the version you desire here
+      - image: maven:3.5.4-jdk-8-slim
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.5
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-    - run: apt-get update; apt-get install -y git
-    - checkout
-    # Set up maven dependencies
-    - restore_cache:
-        keys:
-        - verdict-dependencies-{{ checksum "pom.xml" }}
-        # fallback to using the latest cache if no exact match is found
-        # - v1-dependencies-
-        #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
-    # - run: mvn dependency:go-offline
-    # Setup necessary test data
-    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
-    # Now build and test
-    - run:
-        name: Run unit tests
-        command: mvn test -P jdk8 -Dtest=SparkTpchSelectQueryCoordinatorTest 2> /dev/null
-        no_output_timeout: 30m
-    # - run: mvn test -Dtest=RedshiftTpchSelectQueryCoordinatorTest 2> /dev/null
-    # - run: mvn test -Dtest=ImpalaTpchSelectQueryCoordinatorTest 2> /dev/null
-    # Collect test metadata
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/junit
-    - store_artifacts:
-        path: ~/junit
-    - store_artifacts:
-        path: /tmp/verdictdb-debug.log
-    - save_cache:
-        paths:
-        - ~/.m2
-        key: verdict-dependencies-{{ checksum "pom.xml" }}
+      - run: apt-get update; apt-get install -y git
+      - checkout
+      # Set up maven dependencies
+      - restore_cache:
+          keys:
+            - verdict-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          # - v1-dependencies-
+          #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
+      # - run: mvn dependency:go-offline
+      # Setup necessary test data
+      #    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
+      # Now build and test
+      - run:
+          name: Run unit tests
+          command: mvn test -P jdk8 -Dtest=SparkTpchSelectQueryCoordinatorTest 2> /dev/null
+          no_output_timeout: 30m
+      # - run: mvn test -Dtest=RedshiftTpchSelectQueryCoordinatorTest 2> /dev/null
+      # - run: mvn test -Dtest=ImpalaTpchSelectQueryCoordinatorTest 2> /dev/null
+      # Collect test metadata
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+      - store_artifacts:
+          path: /tmp/verdictdb-debug.log
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: verdict-dependencies-{{ checksum "pom.xml" }}
 
   build-impala-redshift:
     docker:
-    # specify the version you desire here
-    - image: maven:3.5.4-jdk-8-slim
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: mysql:5.5
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      # specify the version you desire here
+      - image: maven:3.5.4-jdk-8-slim
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.5
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-    - run: apt-get update; apt-get install -y git
-    - checkout
-    # Set up maven dependencies
-    - restore_cache:
-        keys:
-        - verdict-dependencies-{{ checksum "pom.xml" }}
-        # fallback to using the latest cache if no exact match is found
-        # - v1-dependencies-
-    #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
-    # - run: mvn dependency:go-offline
-    # Setup necessary test data
-    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
-    # Now build and test
-    - run:
-        name: Run Redshift unit tests
-        command: mvn test -P jdk8 -Dtest=RedshiftTpchSelectQueryCoordinatorTest 2> /dev/null
-        no_output_timeout: 30m
-    - run:
-        name: Run Impala unit tests
-        command: mvn test -P jdk8 -Dtest=ImpalaTpchSelectQueryCoordinatorTest 2> /dev/null
-        no_output_timeout: 30m
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/junit
-    - store_artifacts:
-        path: ~/junit
-    - store_artifacts:
-        path: /tmp/verdictdb-debug.log
-    - save_cache:
-        paths:
-        - ~/.m2
-        key: verdict-dependencies-{{ checksum "pom.xml" }}
+      - run: apt-get update; apt-get install -y git
+      - checkout
+      # Set up maven dependencies
+      - restore_cache:
+          keys:
+            - verdict-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          # - v1-dependencies-
+      #- run: mvn install:install-file -Dfile=src/test/resources/jars/ImpalaJDBC41-2.6.3.jar -DgroupId=com.cloudera -DartifactId=impala-jdbc41 -Dversion=2.6.3 -Dpackaging=jar
+      # - run: mvn dependency:go-offline
+      # Setup necessary test data
+      #    - run: git clone git@github.com:verdictdb/verdictdb-private-resources.git
+      # Now build and test
+      - run:
+          name: Run Redshift unit tests
+          command: mvn test -P jdk8 -Dtest=RedshiftTpchSelectQueryCoordinatorTest 2> /dev/null
+          no_output_timeout: 30m
+      - run:
+          name: Run Impala unit tests
+          command: mvn test -P jdk8 -Dtest=ImpalaTpchSelectQueryCoordinatorTest 2> /dev/null
+          no_output_timeout: 30m
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+      - store_artifacts:
+          path: /tmp/verdictdb-debug.log
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: verdict-dependencies-{{ checksum "pom.xml" }}
 
   build-pyverdict:
     docker:
-    - image: continuumio/miniconda3
-    - image: mysql:5.5
-      environment:
-        MYSQL_DATABASE: test
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    - image: postgres:10
-      environment:
-        POSTGRES_DB: test
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: ""
+      - image: continuumio/miniconda3
+      - image: mysql:5.5
+        environment:
+          MYSQL_DATABASE: test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - image: postgres:10
+        environment:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
@@ -364,7 +364,7 @@ jobs:
       # Set up maven dependencies
       - restore_cache:
           keys:
-          - verdict-dependencies-{{ checksum "pom.xml" }}
+            - verdict-dependencies-{{ checksum "pom.xml" }}
       - run: cd pyverdict; pip install pytest PyMySQL presto-python-client psycopg2; python setup.py install;
       # pytest has an internal error if test_verdictcontext runs after 
       # all other tests.  To avoid this, run before instead.
@@ -376,9 +376,9 @@ jobs:
       # Thus, to properly test the impala connector, we downgrade to python 3.6
       # for the impala tests via another venv, then run all other non-impala 
       # tests using python 3.7.
-      - run: conda create --name py36 python=3.6; 
-      - run: source activate py36; pip install impyla pytest; 
-      - run: source activate py36; cd pyverdict; python setup.py install; pytest tests/test_impala*; 
+      - run: conda create --name py36 python=3.6;
+      - run: source activate py36; pip install impyla pytest;
+      - run: source activate py36; cd pyverdict; python setup.py install; pytest tests/test_impala*;
       - save_cache:
           paths:
             - ~/.m2
@@ -386,32 +386,32 @@ jobs:
 
   deploy-doc:
     docker:
-    - image: continuumio/miniconda3
+      - image: continuumio/miniconda3
     steps:
-    - run: apt-get update; apt-get install -y git
-    - checkout
-    - run: pip install mkdocs mkdocs-material mkdocs-markdownextradata-plugin
-    - run: cd docs; mkdocs build; cd ..; rm .gitignore;
-    - run: git config user.email "pyongjoo@umich.edu"; git config user.name "Yongjoo Park"
-    - run: git add docs/site/*; git commit -m 'init doc';
-    - run: git subtree split --prefix docs/site -b gh-pages
-    - run: git remote add doc-origin git@github.com:verdictdb/verdictdb-doc.git
-    - run: git push -f doc-origin gh-pages:gh-pages
+      - run: apt-get update; apt-get install -y git
+      - checkout
+      - run: pip install mkdocs mkdocs-material mkdocs-markdownextradata-plugin
+      - run: cd docs; mkdocs build; cd ..; rm .gitignore;
+      - run: git config user.email "pyongjoo@umich.edu"; git config user.name "Yongjoo Park"
+      - run: git add docs/site/*; git commit -m 'init doc';
+      - run: git subtree split --prefix docs/site -b gh-pages
+      - run: git remote add doc-origin git@github.com:verdictdb/verdictdb-doc.git
+      - run: git push -f doc-origin gh-pages:gh-pages
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-    - build-jdk7
-    - build-jdk8
-    - build-jdk8-update-codecov
-    - build-spark
-    - build-impala-redshift
-    - build-pyverdict
-    - deploy-doc:
-        filters:
-          branches:
-            only: master
+      - build-jdk7
+      - build-jdk8
+      - build-jdk8-update-codecov
+      - build-spark
+      - build-impala-redshift
+      - build-pyverdict
+      - deploy-doc:
+          filters:
+            branches:
+              only: master
     #- update-codecov
     # - maven-version-check
     # - docker-env-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ jobs:
       # all other tests.  To avoid this, run before instead.
       - run: cd pyverdict; pytest tests/test_verdictcontext.py;
       # ignore redshift tests for now due to unavailable redshift test instance as of 5/16/2019
-      - run: cd pyverdict; pytest --ignore=tests/test_redshift_simple_queries.py --ignore=tests/test_redshift_datatypes.py --ignore=tests/test_redshift_simple_queries.py --ignore=tests/test_redshift_datatypes.py --ignore=tests/test_verdictcontext.py;
+      - run: cd pyverdict; pytest --ignore=tests/test_impala_simple_queries.py --ignore=tests/test_impala_datatypes.py --ignore=tests/test_redshift_simple_queries.py --ignore=tests/test_redshift_datatypes.py --ignore=tests/test_verdictcontext.py;
       # NOTE: To test the impala connector we ought compare the results of
       # verdict impala queries to that of the python impala API.  However,
       # the python impala API, impyla, currently does not support python 3.7.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,13 @@ jobs:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
+      # added because of the issue: https://discuss.circleci.com/t/apt-get-update-return-404/29237/4
+      - run: |
+          sudo rm /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until false;" | sudo tee -a /etc/apt/apt.conf.d/10-nocheckvalid
+          echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/10-archive-pin
       - run: apt-get update; apt-get install -y git
       - checkout
       # Set up maven dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-      - run: apt-get update; apt-get install -y build-essential libkrb5-dev git default-jdk maven
+      - run: apt-get update; apt-get install -y build-essential libkrb5-dev libpq-dev git default-jdk maven
       - checkout
       # Set up maven dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
           rm /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian/ jessie-backports main" | tee -a /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | tee -a /etc/apt/sources.list
+          echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list
+          echo "deb http://deb.debian.org/debian stable-updates main" >> /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
           echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' | tee -a /etc/apt/preferences.d/10-archive-pin
       - run: apt-get update; apt-get install -y git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       # added because of the issue: https://discuss.circleci.com/t/apt-get-update-return-404/29237/4
       - run: |
-          sudo rm /etc/apt/sources.list
+          rm /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until false;" | sudo tee -a /etc/apt/apt.conf.d/10-nocheckvalid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,10 @@ jobs:
       # added because of the issue: https://discuss.circleci.com/t/apt-get-update-return-404/29237/4
       - run: |
           rm /etc/apt/sources.list
-          echo "deb http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
-          echo "Acquire::Check-Valid-Until false;" | sudo tee -a /etc/apt/apt.conf.d/10-nocheckvalid
-          echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/10-archive-pin
+          echo "deb http://archive.debian.org/debian/ jessie-backports main" | tee -a /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | tee -a /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
+          echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' | tee -a /etc/apt/preferences.d/10-archive-pin
       - run: apt-get update; apt-get install -y git
       - checkout
       # Set up maven dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,8 @@ jobs:
       # pytest has an internal error if test_verdictcontext runs after 
       # all other tests.  To avoid this, run before instead.
       - run: cd pyverdict; pytest tests/test_verdictcontext.py;
-      - run: cd pyverdict; pytest --ignore=tests/test_impala_simple_queries.py --ignore=tests/test_impala_datatypes.py --ignore=tests/test_verdictcontext.py;
+      # ignore redshift tests for now due to unavailable redshift test instance as of 5/16/2019
+      - run: cd pyverdict; pytest --ignore=tests/test_redshift_simple_queries.py --ignore=tests/test_redshift_datatypes.py --ignore=tests/test_redshift_simple_queries.py --ignore=tests/test_redshift_datatypes.py --ignore=tests/test_verdictcontext.py;
       # NOTE: To test the impala connector we ought compare the results of
       # verdict impala queries to that of the python impala API.  However,
       # the python impala API, impyla, currently does not support python 3.7.

--- a/pyverdict/tests/test_verdictcontext.py
+++ b/pyverdict/tests/test_verdictcontext.py
@@ -104,45 +104,46 @@ def test_postgres_init_method():
 
     verdict.close()
 
-def test_redshift_factory_method():
-    host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
-    port = int(port)
-
-    user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
-    password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
-    dbname = 'dev'
-
-    verdict = VerdictContext.new_redshift_context(
-        host,
-        port,
-        dbname,
-        user,
-        password,
-    )
-
-    print(verdict.sql('show schemas'))
-
-    verdict.close()
-
-def test_redshift_init_method():
-    host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
-    port = int(port)
-
-    user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
-    password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
-    dbname = 'dev'
-
-    verdict = pyverdict.redshift_context(
-        host,
-        port,
-        dbname,
-        user,
-        password,
-    )
-
-    print(verdict.sql('show schemas'))
-
-    verdict.close()
+# Disabled redshift unit tests due to unavailable test instance
+#  def test_redshift_factory_method():
+    #  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
+    #  port = int(port)
+#
+    #  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
+    #  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
+    #  dbname = 'dev'
+#
+    #  verdict = VerdictContext.new_redshift_context(
+        #  host,
+        #  port,
+        #  dbname,
+        #  user,
+        #  password,
+    #  )
+#
+    #  print(verdict.sql('show schemas'))
+#
+    #  verdict.close()
+#
+#  def test_redshift_init_method():
+    #  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
+    #  port = int(port)
+#
+    #  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
+    #  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
+    #  dbname = 'dev'
+#
+    #  verdict = pyverdict.redshift_context(
+        #  host,
+        #  port,
+        #  dbname,
+        #  user,
+        #  password,
+    #  )
+#
+    #  print(verdict.sql('show schemas'))
+#
+    #  verdict.close()
 
 def test_impala_factory_method():
     host, port = os.environ['VERDICTDB_TEST_IMPALA_HOST'].split(':')

--- a/src/test/java/org/verdictdb/VariantMySqlTpchQueryWithoutScramblesTest.java
+++ b/src/test/java/org/verdictdb/VariantMySqlTpchQueryWithoutScramblesTest.java
@@ -1,17 +1,11 @@
 package org.verdictdb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
@@ -25,9 +19,16 @@ import org.verdictdb.sqlreader.RelationStandardizer;
 import org.verdictdb.sqlsyntax.MysqlSyntax;
 import org.verdictdb.sqlwriter.SelectQueryToSql;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
+import static org.junit.Assert.assertEquals;
+
+@Ignore("This test uses private resources")
 public class VariantMySqlTpchQueryWithoutScramblesTest {
 
   static Connection conn;
@@ -142,7 +143,6 @@ public class VariantMySqlTpchQueryWithoutScramblesTest {
       assertEquals(rs.getDouble(4), result.getDouble(3), 1e-5);
     }
   }
-
 
   // count distinct
   @Test

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -40,7 +40,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class CreateScrambleTableFromSqlTest {
 
-  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+  // Disabled redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
   //  private static final String[] targetDatabases = {"mysql"};
 
   private static Map<String, Pair<Connection, Connection>> connections = new HashMap<>();
@@ -71,7 +73,8 @@ public class CreateScrambleTableFromSqlTest {
     options.setVerdictMetaSchemaName(TEMP_SCHEMA_NAME);
     setupMysql();
     setupImpala();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
     setupPostgresql();
   }
 

--- a/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
+++ b/src/test/java/org/verdictdb/coordinator/MetaDataStatementsTest.java
@@ -51,7 +51,9 @@ public class MetaDataStatementsTest {
 
   private String database;
 
-  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+  // Disabled redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
 
   public MetaDataStatementsTest(String database) {
     this.database = database;
@@ -127,7 +129,8 @@ public class MetaDataStatementsTest {
   public static void setup() throws SQLException, VerdictDBDbmsException, IOException {
     setupMysql();
     setupPostgresql();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
     setupImpala();
   }
 
@@ -135,7 +138,8 @@ public class MetaDataStatementsTest {
   public static void tearDown() throws SQLException {
     tearDownMysql();
     tearDownPostgresql();
-    tearDownRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    tearDownRedshift();
     tearDownImpala();
   }
 
@@ -279,13 +283,13 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
 
     VerdictOption option = new VerdictOption();
-    final String verdictmeta = 
+    final String verdictmeta =
         "verdictmeta" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
     option.setVerdictMetaSchemaName(verdictmeta);
     VerdictContext verdict = new VerdictContext(dbmsconn, option);
-    
-    ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
+
+    ExecutionContext exec =
+        new ExecutionContext(dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql("show schemas");
 
     Set<String> expected = new HashSet<>();
@@ -297,7 +301,7 @@ public class MetaDataStatementsTest {
       //      assertEquals(jdbcRs.getString(1), result.getValue(0));
     }
     assertEquals(expected, actual);
-    
+
     // teardown
     dbmsconn.execute(String.format("drop schema if exists %s", verdictmeta));
   }
@@ -335,13 +339,13 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
 
     VerdictOption option = new VerdictOption();
-    final String verdictmeta = 
+    final String verdictmeta =
         "verdictmeta" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
     option.setVerdictMetaSchemaName(verdictmeta);
     VerdictContext verdict = new VerdictContext(dbmsconn, option);
-    
-    ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
+
+    ExecutionContext exec =
+        new ExecutionContext(dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
 
     // test
@@ -354,7 +358,7 @@ public class MetaDataStatementsTest {
       //      assertEquals(jdbcRs.getString(1), result.getValue(0));
     }
     assertEquals(expected, actual);
-    
+
     // teardown
     dbmsconn.execute(String.format("drop schema if exists %s", verdictmeta));
   }
@@ -396,13 +400,13 @@ public class MetaDataStatementsTest {
             new JdbcConnection(connMap.get(database), syntaxMap.get(database)));
 
     VerdictOption option = new VerdictOption();
-    final String verdictmeta = 
+    final String verdictmeta =
         "verdictmeta" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
     option.setVerdictMetaSchemaName(verdictmeta);
     VerdictContext verdict = new VerdictContext(dbmsconn, option);
-    
-    ExecutionContext exec = new ExecutionContext(
-        dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
+
+    ExecutionContext exec =
+        new ExecutionContext(dbmsconn, verdict.getMetaStore(), verdict.getContextId(), 0, options);
     VerdictSingleResult result = exec.sql(vcsql);
     while (jdbcRs.next()) {
       result.next();
@@ -413,7 +417,7 @@ public class MetaDataStatementsTest {
         assertEquals(jdbcRs.getString(2), result.getValue(1));
       }
     }
-    
+
     // teardown
     dbmsconn.execute(String.format("drop schema if exists %s", verdictmeta));
   }

--- a/src/test/java/org/verdictdb/coordinator/RedshiftHashScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftHashScramblingCoordinatorTest.java
@@ -1,18 +1,10 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.connection.DbmsConnection;
@@ -21,6 +13,16 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class RedshiftHashScramblingCoordinatorTest {
 
   static Connection redshiftConn;
@@ -80,7 +82,8 @@ public class RedshiftHashScramblingCoordinatorTest {
     testScramblingCoordinator("orders", "o_orderkey");
   }
 
-  public void testScramblingCoordinator(String tablename, String columnname) throws VerdictDBException {
+  public void testScramblingCoordinator(String tablename, String columnname)
+      throws VerdictDBException {
     JdbcConnection conn = JdbcConnection.create(redshiftConn);
     conn.setOutputDebugMessage(true);
 
@@ -95,7 +98,8 @@ public class RedshiftHashScramblingCoordinatorTest {
     String originalTable = tablename;
     String scrambledTable = tablename + "_scrambled";
     conn.execute(String.format("drop table if exists %s.%s", REDSHIFT_SCHEMA, scrambledTable));
-    scrambler.scramble(originalSchema, originalTable, originalSchema, scrambledTable, "hash", columnname);
+    scrambler.scramble(
+        originalSchema, originalTable, originalSchema, scrambledTable, "hash", columnname);
 
     // tests
     List<Pair<String, String>> originalColumns = conn.getColumns(REDSHIFT_SCHEMA, originalTable);

--- a/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
  *
  * <p>Some test cases are slightly changed because size of test data are small.
  */
-@Ignore("This test uses private resources")
+@Ignore("This test uses private resources + redshift")
 public class RedshiftTpchSelectQueryCoordinatorTest {
 
   static Connection redshiftConn;

--- a/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftTpchSelectQueryCoordinatorTest.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertEquals;
  *
  * <p>Some test cases are slightly changed because size of test data are small.
  */
+@Ignore("This test uses private resources")
 public class RedshiftTpchSelectQueryCoordinatorTest {
 
   static Connection redshiftConn;

--- a/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/RedshiftUniformScramblingCoordinatorTest.java
@@ -1,18 +1,10 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.connection.DbmsConnection;
@@ -21,6 +13,16 @@ import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class RedshiftUniformScramblingCoordinatorTest {
 
   static Connection redshiftConn;

--- a/src/test/java/org/verdictdb/core/querying/CreateTableAsSelectNodeTest.java
+++ b/src/test/java/org/verdictdb/core/querying/CreateTableAsSelectNodeTest.java
@@ -1,17 +1,10 @@
 package org.verdictdb.core.querying;
 
-import static org.junit.Assert.assertEquals;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
@@ -25,6 +18,15 @@ import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.sqlsyntax.H2Syntax;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class CreateTableAsSelectNodeTest {
 
   static String originalSchema = "originalschema";

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftScrambleManipulationTest.java
@@ -19,6 +19,7 @@ package org.verdictdb.core.scramblingquerying;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
@@ -42,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Created by Dong Young Yoon on 8/16/18. */
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class RedshiftScrambleManipulationTest {
 
   private static Map<String, Connection> connMap = new HashMap<>();

--- a/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftUniformScramblingQueryTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/RedshiftUniformScramblingQueryTest.java
@@ -19,6 +19,7 @@ package org.verdictdb.core.scramblingquerying;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
@@ -35,6 +36,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /** Created by Dong Young Yoon on 8/16/18. */
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class RedshiftUniformScramblingQueryTest {
 
   private static Map<String, Connection> connMap = new HashMap<>();

--- a/src/test/java/org/verdictdb/core/scramblingquerying/TpchScrambleQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/TpchScrambleQueryForAllDatabasesTest.java
@@ -21,6 +21,7 @@ import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,6 +46,7 @@ import java.util.Map;
 import static org.junit.Assert.fail;
 
 /** Created by Dong Young Yoon on 7/18/18. */
+@Ignore("This test uses private resources")
 @RunWith(Parameterized.class)
 public class TpchScrambleQueryForAllDatabasesTest {
 

--- a/src/test/java/org/verdictdb/core/scramblingquerying/TpchScrambleQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/core/scramblingquerying/TpchScrambleQueryForAllDatabasesTest.java
@@ -75,7 +75,9 @@ public class TpchScrambleQueryForAllDatabasesTest {
 
   // TODO: Add support for all four databases
   //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
-  private static final String[] targetDatabases = {"mysql", "impala", "redshift"};
+  // Disabled redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "impala"};
+  //  private static final String[] targetDatabases = {"mysql", "impala", "redshift"};
   //  private static final String[] targetDatabases = {"mysql"};
 
   public TpchScrambleQueryForAllDatabasesTest(String database, String query) {
@@ -151,7 +153,8 @@ public class TpchScrambleQueryForAllDatabasesTest {
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupImpala();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
 
     // TODO: Add below databases too
     //    setupPostgresql();

--- a/src/test/java/org/verdictdb/jdbc41/DriverTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/DriverTest.java
@@ -5,6 +5,7 @@ import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.commons.DatabaseConnectionHelpers;
 import org.verdictdb.commons.VerdictOption;
@@ -21,6 +22,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class DriverTest {
 
   private static final String REDSHIFT_HOST;

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -1,6 +1,14 @@
 package org.verdictdb.jdbc41;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.verdictdb.commons.VerdictOption;
+import org.verdictdb.exception.VerdictDBException;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -14,15 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.verdictdb.commons.VerdictOption;
-import org.verdictdb.exception.VerdictDBException;
+import static org.junit.Assert.assertEquals;
 
 /** Created by Dong Young Yoon on 7/18/18. */
 @RunWith(Parameterized.class)
@@ -122,7 +122,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupImpala();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
     setupPostgresql();
   }
 
@@ -144,7 +145,9 @@ public class JdbcCommonQueryForAllDatabasesTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> databases() {
-    return Arrays.asList("mysql", "impala", "redshift", "postgresql");
+    // Disabled redshift test due to unavailable test instance
+    return Arrays.asList("mysql", "impala", "postgresql");
+    //    return Arrays.asList("mysql", "impala", "redshift", "postgresql");
   }
 
   private static void loadData(Connection conn) throws SQLException {

--- a/src/test/java/org/verdictdb/jdbc41/JdbcMetaDataForRedshiftTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcMetaDataForRedshiftTest.java
@@ -1,18 +1,20 @@
 package org.verdictdb.jdbc41;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.verdictdb.connection.DbmsConnection;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class JdbcMetaDataForRedshiftTest {
 
   static Connection conn;

--- a/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
@@ -1,8 +1,15 @@
 package org.verdictdb.jdbc41;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.postgresql.jdbc.PgSQLXML;
+import org.verdictdb.commons.DatabaseConnectionHelpers;
+import org.verdictdb.commons.VerdictOption;
+import org.verdictdb.exception.VerdictDBException;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -14,16 +21,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.postgresql.jdbc.PgSQLXML;
-import org.verdictdb.commons.DatabaseConnectionHelpers;
-import org.verdictdb.commons.VerdictOption;
-import org.verdictdb.exception.VerdictDBException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /** Created by Dong Young Yoon on 7/18/18. */
 @RunWith(Parameterized.class)
@@ -39,8 +39,9 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
 
   private String database;
 
-  private static final String[] targetDatabases = 
-      {"mysql", "impala", "redshift", "postgresql"};
+  // Disabled redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
 
   public JdbcQueryDataTypeForAllDatabasesTest(String database) {
     this.database = database;
@@ -93,7 +94,7 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
   private static final String POSTGRES_USER = "postgres";
 
   private static final String POSTGRES_PASSWORD = "";
-  
+
   private static final String VERDICT_META_SCHEMA =
       "verdictdbmetaschema_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
@@ -129,7 +130,8 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupPostgresql();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
     setupImpala();
   }
 
@@ -137,7 +139,8 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
   public static void tearDown() throws SQLException {
     tearDownMysql();
     tearDownPostgresql();
-    tearDownRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    tearDownRedshift();
     tearDownImpala();
   }
 

--- a/src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTypeForRedshiftTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTypeForRedshiftTest.java
@@ -1,8 +1,14 @@
 package org.verdictdb.jdbc41;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.verdictdb.connection.DbmsConnection;
+import org.verdictdb.connection.JdbcConnection;
+import org.verdictdb.coordinator.VerdictSingleResultFromDbmsQueryResult;
+import org.verdictdb.exception.VerdictDBDbmsException;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -12,35 +18,32 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 
-//<<<<<<< HEAD:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTestForRedshift.java
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertNotEquals;
-//import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+// <<<<<<< HEAD:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTestForRedshift.java
+// import static org.junit.Assert.assertEquals;
+// import static org.junit.Assert.assertNotEquals;
+// import static org.junit.Assert.fail;
 //
-//import java.sql.Connection;
-//import java.sql.DriverManager;
-//import java.sql.ResultSet;
-//import java.sql.ResultSetMetaData;
-//import java.sql.SQLException;
-//import java.sql.Statement;
-//import java.sql.Timestamp;
+// import java.sql.Connection;
+// import java.sql.DriverManager;
+// import java.sql.ResultSet;
+// import java.sql.ResultSetMetaData;
+// import java.sql.SQLException;
+// import java.sql.Statement;
+// import java.sql.Timestamp;
 //
-//=======
+// =======
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.verdictdb.connection.DbmsConnection;
-import org.verdictdb.connection.JdbcConnection;
-import org.verdictdb.coordinator.VerdictSingleResultFromDbmsQueryResult;
-import org.verdictdb.exception.VerdictDBDbmsException;
+// >>>>>>>
+// origin/master:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTypeForRedshiftTest.java
+// <<<<<<< HEAD:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTestForRedshift.java
+// public class JdbcResultSetMetaDataTestForRedshift {
+// =======
 
-//>>>>>>> origin/master:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTypeForRedshiftTest.java
-//<<<<<<< HEAD:src/test/java/org/verdictdb/jdbc41/JdbcResultSetMetaDataTestForRedshift.java
-//public class JdbcResultSetMetaDataTestForRedshift {
-//=======
-
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class JdbcResultSetMetaDataTypeForRedshiftTest {
 
   static Connection conn;

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /** Created by Dong Young Yoon on 7/18/18. */
-@Ignore("This test uses private resources")
+@Ignore("This test uses private resources + redshift")
 @RunWith(Parameterized.class)
 public class JdbcTpchQueryForAllDatabasesTest {
 
@@ -134,7 +134,8 @@ public class JdbcTpchQueryForAllDatabasesTest {
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
     setupImpala();
-    setupRedshift();
+    // Disabled redshift test due to unavailable test instance
+    //    setupRedshift();
 
     // TODO: Add below databases too
     //    setupPostgresql();

--- a/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcTpchQueryForAllDatabasesTest.java
@@ -5,6 +5,7 @@ import com.google.common.io.Files;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -29,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /** Created by Dong Young Yoon on 7/18/18. */
+@Ignore("This test uses private resources")
 @RunWith(Parameterized.class)
 public class JdbcTpchQueryForAllDatabasesTest {
 

--- a/src/test/java/org/verdictdb/jdbc41/RedshiftTpch10gTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/RedshiftTpch10gTest.java
@@ -1,5 +1,7 @@
 package org.verdictdb.jdbc41;
 
+import org.junit.Ignore;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -13,6 +15,7 @@ import java.sql.Statement;
  *
  * @author Yongjoo Park
  */
+@Ignore("Disabling redshift test due to unavailable test instance")
 public class RedshiftTpch10gTest {
 
   private static final String REDSHIFT_HOST;

--- a/src/test/java/org/verdictdb/jdbc41/VerdictConnectionTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/VerdictConnectionTest.java
@@ -44,7 +44,9 @@ public class VerdictConnectionTest {
 
   private Pair<Connection, Connection> connectionPair;
 
-  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
+  // Disabled redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
 
   public VerdictConnectionTest(String database) {
     this.database = database;
@@ -159,9 +161,9 @@ public class VerdictConnectionTest {
   private void setupImpala() throws SQLException {
     String connectionString = String.format("jdbc:impala://%s", IMPALA_HOST);
     String impalaMetaSchema = "verdictdbmeta_impala";
-    String vcConnectionString = 
-        String.format("jdbc:verdict:impala://%s;verdictdbmetaschema=%s", 
-            IMPALA_HOST, impalaMetaSchema);
+    String vcConnectionString =
+        String.format(
+            "jdbc:verdict:impala://%s;verdictdbmetaschema=%s", IMPALA_HOST, impalaMetaSchema);
     Connection conn = DriverManager.getConnection(connectionString, IMPALA_USER, IMPALA_PASSWORD);
     Connection vc = DriverManager.getConnection(vcConnectionString, IMPALA_USER, IMPALA_PASSWORD);
     connectionPair = ImmutablePair.of(conn, vc);


### PR DESCRIPTION
This is an attempt to enable automatic unit tests on external pull requests via CircleCI.
This PR:
1) disable unit tests using our private resources via `@Ignore` annotation
2) comment out `git pull` on our private resources in the CircleCI configuration

Please note that:
1) Currently our Redshift test instance is down, so CircleCI tests will fail
2) There has been issue with CircleCI image that we use for our jdk7 tests: https://discuss.circleci.com/t/apt-get-update-return-404/29237/8
I have included a temporary fix to it, but we may need to use a different image for a proper fix.