### PR TITLE
Run Presto unit tests locally using a docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,32 +183,33 @@ jobs:
           POSTGRES_DB: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ""
+      - image: starburstdata/presto:latest
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
       - run: apt-get update; apt-get install -y git wget
+      #      - run:
+      #          name: Install Docker client
+      #          command: |
+      #            set -x
+      #            VER="18.09.6"
+      #            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+      #            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+      #            mv /tmp/docker/* /usr/bin
       - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.09.6"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
-          name: install dockerize
+          name: Install Dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.6.1
       - setup_remote_docker
-      - run:
-          name: Launch presto docker image
-          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
+      #      - run:
+      #          name: Launch presto docker image
+      #          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
       - run: docker ps
       - run:
-          name: Wait for presto db
+          name: Wait for Presto Database
           command: dockerize -wait tcp://127.0.0.1:8080 -timeout 1m
       - checkout
 
@@ -228,8 +229,7 @@ jobs:
       # Now build and test
       - run:
           name: Run unit tests
-          command: mvn -P jdk8 -B test -Dtest=PrestoHashScramblingCoordinatorTest 2> /dev/null
-          #          command: mvn -P jdk8 -B test 2> /dev/null
+          command: mvn -P jdk8 -B test 2> /dev/null
           no_output_timeout: 30m
 
       # Check the JDBC service file correctness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
           command: docker ps
       - run:
           name: Increase value for max-requests-queued-per-destination
-          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} /bin/sh -c "echo scheduler.http-client.max-requests-queued-per-destination=32000 >> /etc/presto/config.properties"
+          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} /bin/sh -c "echo scheduler.http-client.max-requests-queued-per-destination=4096 >> /etc/presto/config.properties"
       - run:
           name: Restart Presto with updated configuration value
           command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec -d {} /usr/lib/presto/bin/launcher restart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-      - setup_remote_docker
+      - run: apt-get update; apt-get install -y git wget
       - run:
           name: Install Docker client
           command: |
@@ -197,9 +197,19 @@ jobs:
             curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             mv /tmp/docker/* /usr/bin
-      # launch presto docker
-      - run: docker run -d -p 127.0.0.1:8080:8080 --name verdictdb-presto starburstdata/presto
-      - run: apt-get update; apt-get install -y git
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.6.1
+      - setup_remote_docker
+      - run:
+          name: Launch presto docker image
+          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
+      - run: docker ps
+      - run:
+          name: Wait for presto db
+          command: dockerize -wait tcp://127.0.0.1:8080 -timeout 1m
       - checkout
 
 
@@ -218,7 +228,8 @@ jobs:
       # Now build and test
       - run:
           name: Run unit tests
-          command: mvn -P jdk8 -B test 2> /dev/null
+          command: mvn -P jdk8 -B test -Dtest=PrestoHashScramblingCoordinatorTest 2> /dev/null
+          #          command: mvn -P jdk8 -B test 2> /dev/null
           no_output_timeout: 30m
 
       # Check the JDBC service file correctness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,8 +239,8 @@ jobs:
       # Now build and test
       - run:
           name: Run unit tests
-          command: mvn -P jdk8 -B test -Dtest=PrestoTpchSelectQueryCoordinatorTest 2> /dev/null
-          #          command: mvn -P jdk8 -B test 2> /dev/null
+          command: mvn -P jdk8 -B test 2> /dev/null
+          #          command: mvn -P jdk8 -B test -Dtest=PrestoTpchSelectQueryCoordinatorTest 2> /dev/null
           no_output_timeout: 30m
 
       # Check the JDBC service file correctness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,9 +188,20 @@ jobs:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
     steps:
-      - run: apt-get update; apt-get install -y git
       - setup_remote_docker
+      - run:
+          name: Install Docker client
+          command: |
+            set -x
+            VER="18.09.6"
+            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+            mv /tmp/docker/* /usr/bin
+      # launch presto docker
+      - run: docker run -d -p 127.0.0.1:8080:8080 --name verdictdb-presto starburstdata/presto
+      - run: apt-get update; apt-get install -y git
       - checkout
+
 
       # Set up maven dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
       #      - run:
       #          name: Launch presto docker image
       #          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
-      - run: docker ps
+      #      - run: docker ps
       - run:
           name: Wait for Presto Database
           command: dockerize -wait tcp://127.0.0.1:8080 -timeout 1m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: mysql:5.5
-        command: mysqld --innodb_buffer_pool_size=2G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
+        command: mysqld --innodb_buffer_pool_size=1G --general_log=1 --general_log_file=/tmp/mysql_general.log --slow_query_log=1 --slow_query_log_file=/tmp/mysql_slow_query.log
         environment:
           MYSQL_DATABASE: test
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -187,7 +187,7 @@ jobs:
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m
+      MAVEN_OPTS: -Xmx2G
     steps:
       - run: apt-get update; apt-get install -y git wget
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx2G
+      MAVEN_OPTS: -Xmx1G
     steps:
       - run: apt-get update; apt-get install -y git wget
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
           POSTGRES_DB: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ""
+      - image: starburstdata/presto:latest
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,9 +247,12 @@ jobs:
       - run: bash .circleci/check_jdbc_driver_name.sh
 
       - run:
-          name: Print Presto log
+          name: Print Presto log1
           command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} cat /var/log/presto/*.log
-          
+      - run:
+          name: Print Presto log2
+          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} cat /var/lib/presto/data/var/log/*.log
+
       #- run: mvn -DskipTests -P packaging package
       # Collect test metadata
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,24 +190,34 @@ jobs:
       MAVEN_OPTS: -Xmx3200m
     steps:
       - run: apt-get update; apt-get install -y git wget
+      - run:
+          name: Install Docker client
+          command: |
+            set -x
+            VER="18.09.6"
+            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+            mv /tmp/docker/* /usr/bin
+      - setup_remote_docker
       #      - run:
-      #          name: Install Docker client
-      #          command: |
-      #            set -x
-      #            VER="18.09.6"
-      #            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-      #            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-      #            mv /tmp/docker/* /usr/bin
+      #          name: Launch presto docker image
+      #          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
+      - run:
+          name: List current Docker containers
+          command: docker ps
+      - run:
+          name: Increase value for max-requests-queued-per-destination
+          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} /bin/sh -c "echo scheduler.http-client.max-requests-queued-per-destination=32000 >> /etc/presto/config.properties"
+      - run:
+          name: Restart Presto with updated configuration value
+          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec -d {} /usr/lib/presto/bin/launcher restart
+      #      - run: docker exec -it verdictdb-presto /bin/sh -c "echo 'scheduler.http-client.max-requests-queued-per-destination=32000' >> /etc/presto/config.properties"
+      #      - run: docker exec -it verdictdb-presto cat /etc/presto/config.properties
       - run:
           name: Install Dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.6.1
-      - setup_remote_docker
-      #      - run:
-      #          name: Launch presto docker image
-      #          command: docker run -d -p 8080:8080 --name verdictdb-presto starburstdata/presto
-      #      - run: docker ps
       - run:
           name: Wait for Presto Database
           command: dockerize -wait tcp://127.0.0.1:8080 -timeout 1m
@@ -229,7 +239,8 @@ jobs:
       # Now build and test
       - run:
           name: Run unit tests
-          command: mvn -P jdk8 -B test 2> /dev/null
+          command: mvn -P jdk8 -B test -Dtest=PrestoTpchSelectQueryCoordinatorTest 2> /dev/null
+          #          command: mvn -P jdk8 -B test 2> /dev/null
           no_output_timeout: 30m
 
       # Check the JDBC service file correctness
@@ -397,7 +408,7 @@ jobs:
           keys:
             - verdict-dependencies-{{ checksum "pom.xml" }}
       - run: cd pyverdict; pip install pytest PyMySQL presto-python-client psycopg2; python setup.py install;
-      # pytest has an internal error if test_verdictcontext runs after 
+      # pytest has an internal error if test_verdictcontext runs after
       # all other tests.  To avoid this, run before instead.
       - run: cd pyverdict; pytest tests/test_verdictcontext.py;
       # ignore redshift tests for now due to unavailable redshift test instance as of 5/16/2019
@@ -406,7 +417,7 @@ jobs:
       # verdict impala queries to that of the python impala API.  However,
       # the python impala API, impyla, currently does not support python 3.7.
       # Thus, to properly test the impala connector, we downgrade to python 3.6
-      # for the impala tests via another venv, then run all other non-impala 
+      # for the impala tests via another venv, then run all other non-impala
       # tests using python 3.7.
       - run: conda create --name py36 python=3.6;
       - run: source activate py36; pip install impyla pytest;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,10 @@ jobs:
       # Check the JDBC service file correctness
       - run: bash .circleci/check_jdbc_driver_name.sh
 
+      - run:
+          name: Print Presto log
+          command: docker ps --filter="ancestor=starburstdata/presto:latest" --format "{{.Names}}" | xargs -I{} docker exec {} cat /var/log/presto/*.log
+          
       #- run: mvn -DskipTests -P packaging package
       # Collect test metadata
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,9 +427,11 @@ jobs:
       # Thus, to properly test the impala connector, we downgrade to python 3.6
       # for the impala tests via another venv, then run all other non-impala
       # tests using python 3.7.
-      - run: conda create --name py36 python=3.6;
-      - run: source activate py36; pip install impyla pytest;
-      - run: source activate py36; cd pyverdict; python setup.py install; pytest tests/test_impala*;
+
+      # disable impala unit tests
+      #      - run: conda create --name py36 python=3.6;
+      #      - run: source activate py36; pip install impyla pytest;
+      #      - run: source activate py36; cd pyverdict; python setup.py install; pytest tests/test_impala*;
       - save_cache:
           paths:
             - ~/.m2

--- a/pyverdict/tests/test_presto_datatypes.py
+++ b/pyverdict/tests/test_presto_datatypes.py
@@ -13,11 +13,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 '''
-from datetime import datetime, date, timezone
-import os
-import pyverdict
 import prestodb
+import pyverdict
 import uuid
+from datetime import datetime, timezone
 
 test_schema = 'pyverdict_presto_datatype_test_schema' + str(uuid.uuid4())[:3]
 test_table = 'test_table'
@@ -50,6 +49,7 @@ def test_data_types():
             compare_value(expected_row[j], actual_row[j], types[j])
     tear_down(presto_conn, verdict_conn)
 
+
 def compare_value(expected, actual, coltype):
     if coltype == 'decimal' and expected is not None:
         assert float(expected) == actual
@@ -65,6 +65,7 @@ def compare_value(expected, actual, coltype):
     else:
         assert expected == actual
 
+
 def setup_sandbox():
     '''
     We test the data types defined here: https://prestodb.io/docs/current/language/types.html
@@ -74,11 +75,14 @@ def setup_sandbox():
     1. "time with time zone" is not supported: "Unsupported Hive type: time with time zone"
     2. "timestamp with time zone" is not supported: Unsupported Hive type: timestamp with time zone
     '''
-    hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    hostport = 'localhost:8080'
+    catalog = 'memory'
+    user = 'root'
+    # hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
+    # user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     host, port = hostport.split(':')
     port = int(port)
-    catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
-    user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     password = ''
 
     # create table and populate data
@@ -105,7 +109,7 @@ def setup_sandbox():
             charCol             CHAR(4),
             varcharCol          VARCHAR(4)
         )""".format(test_schema, test_table)
-        )
+                )
     cur.fetchall()
 
     cur.execute("""
@@ -122,7 +126,7 @@ def setup_sandbox():
             cast('ab' as char(4)),
             cast('abcd' as varchar(4))
         )""".format(test_schema, test_table)
-        )
+                )
     cur.fetchall()
 
     cur.execute("""
@@ -131,7 +135,7 @@ def setup_sandbox():
             NULL, NULL, NULL, NULL, NULL,
             NULL, NULL
         )""".format(test_schema, test_table)
-        )
+                )
     cur.fetchall()
 
     # create verdict connection
@@ -139,6 +143,7 @@ def setup_sandbox():
     # mysql_jar = os.path.join(thispath, 'lib', 'mysql-connector-java-5.1.46.jar')
     verdict_conn = verdict_connect(host, port, catalog, user)
     return (presto_conn, verdict_conn)
+
 
 def tear_down(presto_conn, verdict_conn):
     cur = presto_conn.cursor()
@@ -148,12 +153,13 @@ def tear_down(presto_conn, verdict_conn):
     cur.fetchall()
     verdict_conn.close()
 
+
 def verdict_connect(host, port, catalog, usr):
     connection_string = \
         'jdbc:presto://{:s}:{:d}/{:s}?user={:s}'.format(host, port, catalog, usr)
     return pyverdict.VerdictContext(connection_string)
 
+
 def presto_connect(host, port, usr, catalog):
     return prestodb.dbapi.connect(
         host=host, port=port, user=usr, catalog=catalog)
-

--- a/pyverdict/tests/test_presto_simple_queries.py
+++ b/pyverdict/tests/test_presto_simple_queries.py
@@ -13,11 +13,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 '''
-from datetime import datetime, date, timezone
-import os
-import pyverdict
 import prestodb
+import pyverdict
 import uuid
+from datetime import datetime, timezone
 
 test_schema = 'pyverdict_presto_simple_query_test_schema' + str(uuid.uuid4())[:3]
 test_table = 'test_table'
@@ -30,11 +29,14 @@ verdict_conn = None
 def setup_module(module):
     global presto_conn, verdict_conn
 
-    hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    hostport = 'localhost:8080'
+    catalog = 'memory'
+    user = 'root'
+    # hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
+    # user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     host, port = hostport.split(':')
     port = int(port)
-    catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
-    user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     password = ''
 
     # setup regular presto_conn
@@ -73,7 +75,7 @@ def setup_module(module):
         'jdbc:presto://{:s}:{:d}/{:s}?user={:s}'.format(host, port, catalog, user)
     verdict_conn = pyverdict.VerdictContext(connection_string)
     verdict_conn.sql('CREATE SCRAMBLE {}.{} FROM {}.{} BLOCKSIZE 200'
-        .format(test_schema, test_scramble, test_schema, test_table))
+                     .format(test_schema, test_scramble, test_schema, test_table))
 
 
 def teardown_module(module):
@@ -177,4 +179,3 @@ class TestClass:
         assert actual is not None
         assert expected * 1.2 >= actual
         assert expected * 0.8 <= actual
-

--- a/pyverdict/tests/test_verdictcontext.py
+++ b/pyverdict/tests/test_verdictcontext.py
@@ -19,11 +19,14 @@ from pyverdict import VerdictContext
 
 
 def test_presto_factory_method():
-    hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
+    # user = os.environ['VERDICTDB_TEST_PRESTO_USER']
+    hostport = 'localhost:8080'
+    catalog = 'memory'
+    user = 'root'
     host, port = hostport.split(':')
     port = int(port)
-    catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
-    user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     password = ''
 
     verdict = VerdictContext.new_presto_context(host, catalog, user, port=port)
@@ -31,18 +34,23 @@ def test_presto_factory_method():
 
     verdict.close()
 
+
 def test_presto_init_method():
-    hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # hostport = os.environ['VERDICTDB_TEST_PRESTO_HOST']
+    # catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
+    # user = os.environ['VERDICTDB_TEST_PRESTO_USER']
+    hostport = 'localhost:8080'
+    catalog = 'memory'
+    user = 'root'
     host, port = hostport.split(':')
     port = int(port)
-    catalog = os.environ['VERDICTDB_TEST_PRESTO_CATALOG']
-    user = os.environ['VERDICTDB_TEST_PRESTO_USER']
     password = ''
 
     verdict = pyverdict.presto_context(host, catalog, user, port=port)
     print(verdict.sql('show schemas'))
 
     verdict.close()
+
 
 def test_mysql_factory_method():
     host = 'localhost'
@@ -55,6 +63,7 @@ def test_mysql_factory_method():
 
     verdict.close()
 
+
 def test_mysql_init_method():
     host = 'localhost'
     port = 3306
@@ -65,6 +74,7 @@ def test_mysql_init_method():
     print(verdict.sql('show schemas'))
 
     verdict.close()
+
 
 def test_postgres_factory_method():
     host = 'localhost'
@@ -85,6 +95,7 @@ def test_postgres_factory_method():
 
     verdict.close()
 
+
 def test_postgres_init_method():
     host = 'localhost'
     port = 5432
@@ -104,46 +115,47 @@ def test_postgres_init_method():
 
     verdict.close()
 
+
 # Disabled redshift unit tests due to unavailable test instance
 #  def test_redshift_factory_method():
-    #  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
-    #  port = int(port)
+#  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
+#  port = int(port)
 #
-    #  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
-    #  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
-    #  dbname = 'dev'
+#  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
+#  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
+#  dbname = 'dev'
 #
-    #  verdict = VerdictContext.new_redshift_context(
-        #  host,
-        #  port,
-        #  dbname,
-        #  user,
-        #  password,
-    #  )
+#  verdict = VerdictContext.new_redshift_context(
+#  host,
+#  port,
+#  dbname,
+#  user,
+#  password,
+#  )
 #
-    #  print(verdict.sql('show schemas'))
+#  print(verdict.sql('show schemas'))
 #
-    #  verdict.close()
+#  verdict.close()
 #
 #  def test_redshift_init_method():
-    #  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
-    #  port = int(port)
+#  host, port = os.environ['VERDICTDB_TEST_REDSHIFT_ENDPOINT'].split(':')
+#  port = int(port)
 #
-    #  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
-    #  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
-    #  dbname = 'dev'
+#  user = os.environ['VERDICTDB_TEST_REDSHIFT_USER']
+#  password = os.environ['VERDICTDB_TEST_REDSHIFT_PASSWORD']
+#  dbname = 'dev'
 #
-    #  verdict = pyverdict.redshift_context(
-        #  host,
-        #  port,
-        #  dbname,
-        #  user,
-        #  password,
-    #  )
+#  verdict = pyverdict.redshift_context(
+#  host,
+#  port,
+#  dbname,
+#  user,
+#  password,
+#  )
 #
-    #  print(verdict.sql('show schemas'))
+#  print(verdict.sql('show schemas'))
 #
-    #  verdict.close()
+#  verdict.close()
 
 def test_impala_factory_method():
     host, port = os.environ['VERDICTDB_TEST_IMPALA_HOST'].split(':')
@@ -158,4 +170,3 @@ def test_impala_factory_method():
     print(verdict.sql('show schemas'))
 
     verdict.close()
-

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -812,7 +812,7 @@ full_table_name
     ;
 
 table_name
-    : (schema=id '.')? table=id
+    : ((catalog=id '.' schema=id '.') | (schema=id '.'))? table=id
     ;
 
 //table_name

--- a/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
@@ -16,14 +16,16 @@
 
 package org.verdictdb.connection;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.sqlsyntax.SqlSyntax;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.verdictdb.exception.VerdictDBDbmsException;
-import org.verdictdb.sqlsyntax.SqlSyntax;
 
 /**
  * Offers the same functionality as DbmsConnection; however, returns cached metadata whenever
@@ -83,9 +85,9 @@ public class CachedDbmsConnection extends DbmsConnection implements MetaDataProv
   private HashMap<Pair<String, String>, List<String>> partitionCache = new HashMap<>();
 
   // Get column name and type
-  private HashMap<Pair<String, String>, List<Pair<String, String>>> columnsCache = new HashMap<>();
-  
-  
+  private HashMap<Triple<String, String, String>, List<Pair<String, String>>> columnsCache =
+      new HashMap<>();
+
   public void clearCache() {
     schemaCache.clear();
     tablesCache.clear();
@@ -114,9 +116,8 @@ public class CachedDbmsConnection extends DbmsConnection implements MetaDataProv
     }
     return getTablesWithoutCaching(schema);
   }
-  
-  public List<String> getTablesWithoutCaching(String schema) 
-      throws VerdictDBDbmsException {
+
+  public List<String> getTablesWithoutCaching(String schema) throws VerdictDBDbmsException {
     synchronized (this) {
       List<String> tables = new ArrayList<>();
       tablesCache.put(schema, originalConn.getTables(schema));
@@ -128,13 +129,29 @@ public class CachedDbmsConnection extends DbmsConnection implements MetaDataProv
   @Override
   public List<Pair<String, String>> getColumns(String schema, String table)
       throws VerdictDBDbmsException {
-    Pair<String, String> key = new ImmutablePair<>(schema, table);
+    Triple<String, String, String> key = new ImmutableTriple<>("", schema, table);
     if (columnsCache.containsKey(key) && !columnsCache.get(key).isEmpty()) {
       return columnsCache.get(key);
     }
     synchronized (this) {
       List<Pair<String, String>> columns = new ArrayList<>();
       columnsCache.put(key, originalConn.getColumns(schema, table));
+      columns.addAll(columnsCache.get(key));
+      return columns;
+    }
+  }
+
+  // ignores catalog for now
+  @Override
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table)
+      throws VerdictDBDbmsException {
+    Triple<String, String, String> key = new ImmutableTriple<>(catalog, schema, table);
+    if (columnsCache.containsKey(key) && !columnsCache.get(key).isEmpty()) {
+      return columnsCache.get(key);
+    }
+    synchronized (this) {
+      List<Pair<String, String>> columns = new ArrayList<>();
+      columnsCache.put(key, originalConn.getColumns(catalog, schema, table));
       columns.addAll(columnsCache.get(key));
       return columns;
     }

--- a/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
+++ b/src/main/java/org/verdictdb/connection/CachedDbmsConnection.java
@@ -85,6 +85,10 @@ public class CachedDbmsConnection extends DbmsConnection implements MetaDataProv
   private HashMap<Pair<String, String>, List<String>> partitionCache = new HashMap<>();
 
   // Get column name and type
+  // Key of this map (i.e., table reference) is in the format of <catalog, schema, table>
+  // For many databases where catalog == schema,
+  // only the latter two elements are used and the value of 'catalog' is empty.
+  // When catalog != schema (e.g., presto), we set all three values for the key.
   private HashMap<Triple<String, String, String>, List<Pair<String, String>>> columnsCache =
       new HashMap<>();
 

--- a/src/main/java/org/verdictdb/connection/CachedMetaDataProvider.java
+++ b/src/main/java/org/verdictdb/connection/CachedMetaDataProvider.java
@@ -16,13 +16,13 @@
 
 package org.verdictdb.connection;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.exception.VerdictDBDbmsException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 public class CachedMetaDataProvider implements MetaDataProvider {
 
@@ -63,6 +63,18 @@ public class CachedMetaDataProvider implements MetaDataProvider {
 
   @Override
   public List<Pair<String, String>> getColumns(String schema, String table)
+      throws VerdictDBDbmsException {
+    Pair<String, String> key = new ImmutablePair<>(schema, table);
+    if (columnsCache.containsKey(key) && !columnsCache.get(key).isEmpty()) {
+      return columnsCache.get(key);
+    }
+    columnsCache.put(key, metaProvider.getColumns(schema, table));
+    return columnsCache.get(key);
+  }
+
+  // ignores catalog
+  @Override
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table)
       throws VerdictDBDbmsException {
     Pair<String, String> key = new ImmutablePair<>(schema, table);
     if (columnsCache.containsKey(key) && !columnsCache.get(key).isEmpty()) {

--- a/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/ConcurrentJdbcConnection.java
@@ -16,18 +16,18 @@
 
 package org.verdictdb.connection;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.verdictdb.commons.VerdictDBLogger;
+import org.verdictdb.exception.VerdictDBDbmsException;
+import org.verdictdb.sqlsyntax.SqlSyntax;
+import org.verdictdb.sqlsyntax.SqlSyntaxList;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.verdictdb.commons.VerdictDBLogger;
-import org.verdictdb.exception.VerdictDBDbmsException;
-import org.verdictdb.sqlsyntax.SqlSyntax;
-import org.verdictdb.sqlsyntax.SqlSyntaxList;
 
 /**
  * Maintains a pool of multiple java.sql.Connections to provide concurrent execution of queries to
@@ -113,6 +113,12 @@ public class ConcurrentJdbcConnection extends DbmsConnection {
   public List<Pair<String, String>> getColumns(String schema, String table)
       throws VerdictDBDbmsException {
     return getNextConnection().getColumns(schema, table);
+  }
+
+  @Override
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table)
+      throws VerdictDBDbmsException {
+    return getNextConnection().getColumns(catalog, schema, table);
   }
 
   @Override

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -99,7 +99,9 @@ public class JdbcConnection extends DbmsConnection {
 
     // This is temporary fix to have 'memory' catalog connection for unit tests
     try {
-      if (syntax instanceof PrestoHiveSyntax && conn.getCatalog().equalsIgnoreCase("memory")) {
+      if (syntax instanceof PrestoHiveSyntax
+          && conn.getCatalog() != null
+          && conn.getCatalog().equalsIgnoreCase("memory")) {
         syntax = new PrestoMemorySyntax();
       }
     } catch (SQLException e) {

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -98,8 +98,12 @@ public class JdbcConnection extends DbmsConnection {
     SqlSyntax syntax = SqlSyntaxList.getSyntaxFromConnectionString(connectionString);
 
     // This is temporary fix to have 'memory' catalog connection for unit tests
-    if (syntax instanceof PrestoHiveSyntax && connectionString.contains("memory")) {
-      syntax = new PrestoMemorySyntax();
+    try {
+      if (syntax instanceof PrestoHiveSyntax && conn.getCatalog().equalsIgnoreCase("memory")) {
+        syntax = new PrestoMemorySyntax();
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
     }
 
     JdbcConnection jdbcConn = null;

--- a/src/main/java/org/verdictdb/connection/JdbcConnection.java
+++ b/src/main/java/org/verdictdb/connection/JdbcConnection.java
@@ -24,6 +24,8 @@ import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.sqlsyntax.HiveSyntax;
 import org.verdictdb.sqlsyntax.ImpalaSyntax;
 import org.verdictdb.sqlsyntax.PostgresqlSyntax;
+import org.verdictdb.sqlsyntax.PrestoHiveSyntax;
+import org.verdictdb.sqlsyntax.PrestoMemorySyntax;
 import org.verdictdb.sqlsyntax.PrestoSyntax;
 import org.verdictdb.sqlsyntax.RedshiftSyntax;
 import org.verdictdb.sqlsyntax.SparkSyntax;
@@ -94,6 +96,12 @@ public class JdbcConnection extends DbmsConnection {
     }
 
     SqlSyntax syntax = SqlSyntaxList.getSyntaxFromConnectionString(connectionString);
+
+    // This is temporary fix to have 'memory' catalog connection for unit tests
+    if (syntax instanceof PrestoHiveSyntax && connectionString.contains("memory")) {
+      syntax = new PrestoMemorySyntax();
+    }
+
     JdbcConnection jdbcConn = null;
     if (syntax instanceof PrestoSyntax) {
       // To handle that Presto's JDBC driver is not compatible with JDK7,
@@ -272,6 +280,48 @@ public class JdbcConnection extends DbmsConnection {
       throws VerdictDBDbmsException {
     List<Pair<String, String>> columns = new ArrayList<>();
     String sql = syntax.getColumnsCommand(schema, table);
+
+    try {
+      DbmsQueryResult queryResult = executeQuery(sql);
+      while (queryResult.next()) {
+        String type;
+        if (syntax instanceof PostgresqlSyntax) {
+          type = queryResult.getString(syntax.getColumnTypeColumnIndex());
+          if (queryResult.getInt(((PostgresqlSyntax) syntax).getCharacterMaximumLengthColumnIndex())
+              != 0) {
+            type =
+                type
+                    + "("
+                    + queryResult.getInt(
+                        ((PostgresqlSyntax) syntax).getCharacterMaximumLengthColumnIndex())
+                    + ")";
+          }
+        } else {
+          type = queryResult.getString(syntax.getColumnTypeColumnIndex());
+        }
+        type = type.toLowerCase();
+
+        columns.add(
+            new ImmutablePair<>(queryResult.getString(syntax.getColumnNameColumnIndex()), type));
+      }
+
+    } catch (Exception e) {
+      if (syntax instanceof RedshiftSyntax
+          && e.getMessage().matches("(?s).*schema .* does not exist;.*")) {
+        return columns;
+      } else {
+        throw e;
+      }
+    }
+
+    return columns;
+  }
+
+  @Override
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table)
+      throws VerdictDBDbmsException {
+    List<Pair<String, String>> columns = new ArrayList<>();
+    String sql = syntax.getColumnsCommand(catalog, schema, table);
 
     try {
       DbmsQueryResult queryResult = executeQuery(sql);

--- a/src/main/java/org/verdictdb/connection/MetaDataProvider.java
+++ b/src/main/java/org/verdictdb/connection/MetaDataProvider.java
@@ -16,10 +16,10 @@
 
 package org.verdictdb.connection;
 
-import java.util.List;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.exception.VerdictDBDbmsException;
+
+import java.util.List;
 
 public interface MetaDataProvider {
 
@@ -28,6 +28,9 @@ public interface MetaDataProvider {
   List<String> getTables(String schema) throws VerdictDBDbmsException;
 
   public List<Pair<String, String>> getColumns(String schema, String table)
+      throws VerdictDBDbmsException;
+
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table)
       throws VerdictDBDbmsException;
 
   public List<String> getPartitionColumns(String schema, String table)

--- a/src/main/java/org/verdictdb/connection/StaticMetaData.java
+++ b/src/main/java/org/verdictdb/connection/StaticMetaData.java
@@ -16,11 +16,6 @@
 
 package org.verdictdb.connection;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -28,6 +23,11 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.verdictdb.commons.DataTypeConverter;
 import org.verdictdb.exception.VerdictDBDbmsException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class StaticMetaData implements MetaDataProvider {
 
@@ -123,6 +123,17 @@ public class StaticMetaData implements MetaDataProvider {
 
   @Override
   public List<Pair<String, String>> getColumns(String schema, String table) {
+    List<Pair<String, String>> nameAndType = new ArrayList<>();
+    List<Pair<String, Integer>> nameAndIntType = columns.get(new ImmutablePair<>(schema, table));
+    for (Pair<String, Integer> a : nameAndIntType) {
+      nameAndType.add(Pair.of(a.getLeft(), DataTypeConverter.typeName(a.getRight())));
+    }
+    return nameAndType;
+  }
+
+  // ignores catalog
+  @Override
+  public List<Pair<String, String>> getColumns(String catalog, String schema, String table) {
     List<Pair<String, String>> nameAndType = new ArrayList<>();
     List<Pair<String, Integer>> nameAndIntType = columns.get(new ImmutablePair<>(schema, table));
     for (Pair<String, Integer> a : nameAndIntType) {

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -709,7 +709,7 @@ public class ExecutionContext {
         columns = conn.getColumns(defaultSchema, t.getTableName());
         tableInfo = new StaticMetaData.TableInfo(defaultSchema, t.getTableName());
       } else {
-        columns = conn.getColumns(t.getSchemaName(), t.getTableName());
+        columns = conn.getColumns(t.getCatalogName(), t.getSchemaName(), t.getTableName());
         tableInfo = new StaticMetaData.TableInfo(t.getSchemaName(), t.getTableName());
       }
       List<Pair<String, Integer>> colInfo = new ArrayList<>();

--- a/src/main/java/org/verdictdb/core/sqlobject/BaseTable.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/BaseTable.java
@@ -27,9 +27,19 @@ public class BaseTable extends AbstractRelation {
 
   private static final long serialVersionUID = 8758804572670242146L;
 
+  String catalogName;
+
   String schemaName;
 
   String tableName;
+
+  public BaseTable(
+      String catalogName, String schemaName, String tableName, String tableSourceAlias) {
+    if (catalogName != null) this.catalogName = catalogName;
+    if (schemaName != null) this.schemaName = schemaName;
+    this.tableName = tableName;
+    if (tableSourceAlias != null) super.setAliasName(tableSourceAlias);
+  }
 
   public BaseTable(String schemaName, String tableName, String tableSourceAlias) {
     this.schemaName = schemaName;
@@ -54,6 +64,10 @@ public class BaseTable extends AbstractRelation {
 
   public String getSchemaName() {
     return schemaName;
+  }
+
+  public String getCatalogName() {
+    return catalogName;
   }
 
   public void setSchemaName(String schemaName) {

--- a/src/main/java/org/verdictdb/sqlreader/RelationGen.java
+++ b/src/main/java/org/verdictdb/sqlreader/RelationGen.java
@@ -16,9 +16,6 @@
 
 package org.verdictdb.sqlreader;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.verdictdb.core.sqlobject.AbstractRelation;
 import org.verdictdb.core.sqlobject.AliasedColumn;
 import org.verdictdb.core.sqlobject.AsteriskColumn;
@@ -34,6 +31,9 @@ import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.UnnamedColumn;
 import org.verdictdb.parser.VerdictSQLParser;
 import org.verdictdb.parser.VerdictSQLParserBaseVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
 
@@ -132,16 +132,21 @@ public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
                     elem = g.visit(ctx.expression());
                     if (elem instanceof BaseColumn) {
                       if (ctx.column_alias() != null) {
-                        elem = new AliasedColumn((BaseColumn) elem, stripQuote(ctx.column_alias().getText()));
+                        elem =
+                            new AliasedColumn(
+                                (BaseColumn) elem, stripQuote(ctx.column_alias().getText()));
                       }
                     } else if (elem instanceof ColumnOp) {
                       if (ctx.column_alias() != null) {
-                        elem = new AliasedColumn((ColumnOp) elem, stripQuote(ctx.column_alias().getText()));
+                        elem =
+                            new AliasedColumn(
+                                (ColumnOp) elem, stripQuote(ctx.column_alias().getText()));
                       }
                     } else if (elem instanceof ConstantColumn) {
                       if (ctx.column_alias() != null) {
                         elem =
-                            new AliasedColumn((ConstantColumn) elem, stripQuote(ctx.column_alias().getText()));
+                            new AliasedColumn(
+                                (ConstantColumn) elem, stripQuote(ctx.column_alias().getText()));
                       }
                     }
                   }
@@ -243,7 +248,7 @@ public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
       if (ctx.search_condition() == null) {
         throw new RuntimeException("The join condition for a inner join does not exist.");
       }
-      
+
       AbstractRelation r = this.visit(ctx.table_source());
       CondGen g = new CondGen();
       UnnamedColumn cond = g.visit(ctx.search_condition());
@@ -292,28 +297,45 @@ public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
   public AbstractRelation visitHinted_table_name_item(
       VerdictSQLParser.Hinted_table_name_itemContext ctx) {
     AbstractRelation r = null;
+    VerdictSQLParser.IdContext catalog = ctx.table_name_with_hint().table_name().catalog;
+    VerdictSQLParser.IdContext schema = ctx.table_name_with_hint().table_name().schema;
+    VerdictSQLParser.IdContext table = ctx.table_name_with_hint().table_name().table;
     if (ctx.as_table_alias() != null) {
-      if (ctx.table_name_with_hint().table_name().schema != null) {
-        r =
-            new BaseTable(
-                stripQuote(ctx.table_name_with_hint().table_name().schema.getText()),
-                stripQuote(ctx.table_name_with_hint().table_name().table.getText()),
-                stripQuote(ctx.as_table_alias().table_alias().getText()));
-      } else {
-        r =
-            BaseTable.getBaseTableWithoutSchema(
-                stripQuote(ctx.table_name_with_hint().table_name().table.getText()),
-                stripQuote(ctx.as_table_alias().table_alias().getText()));
-      }
+      r =
+          new BaseTable(
+              catalog != null ? stripQuote(catalog.getText()) : null,
+              schema != null ? stripQuote(schema.getText()) : null,
+              stripQuote(table.getText()),
+              stripQuote(ctx.as_table_alias().table_alias().getText()));
+      //      if (ctx.table_name_with_hint().table_name().schema != null) {
+      //        r =
+      //            new BaseTable(
+      //                stripQuote(ctx.table_name_with_hint().table_name().catalog.getText()),
+      //                stripQuote(ctx.table_name_with_hint().table_name().schema.getText()),
+      //                stripQuote(ctx.table_name_with_hint().table_name().table.getText()),
+      //                stripQuote(ctx.as_table_alias().table_alias().getText()));
+      //      } else {
+      //        r =
+      //            BaseTable.getBaseTableWithoutSchema(
+      //                stripQuote(ctx.table_name_with_hint().table_name().table.getText()),
+      //                stripQuote(ctx.as_table_alias().table_alias().getText()));
+      //      }
     } else {
-      if (ctx.table_name_with_hint().table_name().schema != null) {
-        r =
-            new BaseTable(
-                stripQuote(ctx.table_name_with_hint().table_name().schema.getText()),
-                stripQuote(ctx.table_name_with_hint().table_name().table.getText()));
-      } else {
-        r = new BaseTable(stripQuote(ctx.table_name_with_hint().table_name().table.getText()));
-      }
+      r =
+          new BaseTable(
+              catalog != null ? stripQuote(catalog.getText()) : null,
+              schema != null ? stripQuote(schema.getText()) : null,
+              stripQuote(table.getText()),
+              null);
+      //      if (ctx.table_name_with_hint().table_name().schema != null) {
+      //        r =
+      //            new BaseTable(
+      //                stripQuote(ctx.table_name_with_hint().table_name().schema.getText()),
+      //                stripQuote(ctx.table_name_with_hint().table_name().table.getText()));
+      //      } else {
+      //        r = new
+      // BaseTable(stripQuote(ctx.table_name_with_hint().table_name().table.getText()));
+      //      }
     }
     return r;
   }

--- a/src/main/java/org/verdictdb/sqlsyntax/H2Syntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/H2Syntax.java
@@ -16,10 +16,10 @@
 
 package org.verdictdb.sqlsyntax;
 
+import com.google.common.collect.Lists;
+
 import java.util.Collection;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 public class H2Syntax extends SqlSyntax {
 
@@ -80,6 +80,11 @@ public class H2Syntax extends SqlSyntax {
 
   @Override
   public String getColumnsCommand(String schema, String table) {
+    return "show columns from " + quoteName(table) + " from " + quoteName(schema);
+  }
+
+  @Override
+  public String getColumnsCommand(String catalog, String schema, String table) {
     return "show columns from " + quoteName(table) + " from " + quoteName(schema);
   }
 

--- a/src/main/java/org/verdictdb/sqlsyntax/MysqlSyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/MysqlSyntax.java
@@ -16,12 +16,12 @@
 
 package org.verdictdb.sqlsyntax;
 
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 public class MysqlSyntax extends SqlSyntax {
 
@@ -51,6 +51,11 @@ public class MysqlSyntax extends SqlSyntax {
 
   @Override
   public String getColumnsCommand(String schema, String table) {
+    return "show columns in " + quoteName(table) + " in " + quoteName(schema);
+  }
+
+  @Override
+  public String getColumnsCommand(String catalog, String schema, String table) {
     return "show columns in " + quoteName(table) + " in " + quoteName(schema);
   }
 
@@ -206,28 +211,20 @@ public class MysqlSyntax extends SqlSyntax {
 
   /**
    * The following query returns 9.6757 (9.6757 / 100 = 0.0968):
-   * 
-   * select stddev(c)
-   * from (
-   *     select v, count(*) as c
-   *     from (
-   *         select conv(substr(md5(value), 1, 8), 16, 10) % 100 as v
-   *         from mytable
-   *     ) t1
-   *     group by v
-   * ) t2;
-   * 
-   * where mytable contains the integers from 0 to 10000.
-   * 
-   * Note that the stddev of rand() is sqrt(0.01 * 0.99) = 0.09949874371.
+   *
+   * <p>select stddev(c) from ( select v, count(*) as c from ( select conv(substr(md5(value), 1, 8),
+   * 16, 10) % 100 as v from mytable ) t1 group by v ) t2;
+   *
+   * <p>where mytable contains the integers from 0 to 10000.
+   *
+   * <p>Note that the stddev of rand() is sqrt(0.01 * 0.99) = 0.09949874371.
    */
   @Override
   public String hashFunction(String column) {
-    String f = String.format(
-        "(conv(substr(md5(%s), 1, 8), 16, 10) %% %d) / %d",
-        column, hashPrecision, hashPrecision);
+    String f =
+        String.format(
+            "(conv(substr(md5(%s), 1, 8), 16, 10) %% %d) / %d",
+            column, hashPrecision, hashPrecision);
     return f;
   }
-
-
 }

--- a/src/main/java/org/verdictdb/sqlsyntax/PrestoMemorySyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/PrestoMemorySyntax.java
@@ -1,7 +1,26 @@
+/*
+ *    Copyright 2018 University of Michigan
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.verdictdb.sqlsyntax;
 
-/**
- * Created by Dong Young Yoon on 2019-05-29.
- */
-public class PrestoMemorySyntax {
+/** Created by Dong Young Yoon on 2019-05-29. */
+public class PrestoMemorySyntax extends PrestoSyntax {
+
+  @Override
+  public String getQuoteString() {
+    return "";
+  }
 }

--- a/src/main/java/org/verdictdb/sqlsyntax/PrestoMemorySyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/PrestoMemorySyntax.java
@@ -1,0 +1,7 @@
+package org.verdictdb.sqlsyntax;
+
+/**
+ * Created by Dong Young Yoon on 2019-05-29.
+ */
+public class PrestoMemorySyntax {
+}

--- a/src/main/java/org/verdictdb/sqlsyntax/PrestoSyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/PrestoSyntax.java
@@ -49,7 +49,7 @@ public class PrestoSyntax extends SqlSyntax {
 
   @Override
   public String getColumnsCommand(String catalog, String schema, String table) {
-    if (!catalog.isEmpty()) {
+    if (catalog != null && !catalog.isEmpty()) {
       return "DESCRIBE " + quoteName(catalog) + "." + quoteName(schema) + "." + quoteName(table);
     } else {
       return "DESCRIBE " + quoteName(schema) + "." + quoteName(table);

--- a/src/main/java/org/verdictdb/sqlsyntax/SqlSyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/SqlSyntax.java
@@ -31,6 +31,8 @@ public abstract class SqlSyntax {
 
   public abstract String getColumnsCommand(String schema, String table);
 
+  public abstract String getColumnsCommand(String catalog, String schema, String table);
+
   // The column index that stored meta information in the original database
   public abstract int getColumnTypeColumnIndex();
 
@@ -53,33 +55,33 @@ public abstract class SqlSyntax {
   public abstract int getTableNameColumnIndex();
 
   public abstract String randFunction();
-  
+
   /**
-   * This indicates the size of each block. Using a smaller block increases the speed at the cost
-   * of some processing overhead.
+   * This indicates the size of each block. Using a smaller block increases the speed at the cost of
+   * some processing overhead.
+   *
    * @return
    */
   public long getRecommendedblockSize() {
     return (int) 1e6;
   }
-  
-  
+
   /**
    * Returns a hash value between 0 (inclusive) and 1 (exclusive).
-   * 
-   * This hash function is supposed to provide good randomization quality. That is,
-   * when an arbitrary set of elements are hashed, the distribution should be even.
-   * 
-   * It is important to note that the argument is already quoted column names or values.
-   * 
+   *
+   * <p>This hash function is supposed to provide good randomization quality. That is, when an
+   * arbitrary set of elements are hashed, the distribution should be even.
+   *
+   * <p>It is important to note that the argument is already quoted column names or values.
+   *
    * @param column The column name
    * @param upper_bound The upper bound
    * @return Hashed integer
    */
   public abstract String hashFunction(String column);
-  
+
   // this indicates 0.00001 precision
-  final protected int hashPrecision = 100000;
+  protected final int hashPrecision = 100000;
 
   public abstract boolean isAsRequiredBeforeSelectInCreateTable();
 

--- a/src/main/java/org/verdictdb/sqlsyntax/SqlSyntaxList.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/SqlSyntaxList.java
@@ -43,7 +43,7 @@ public class SqlSyntaxList {
 
   public static SqlSyntax getSyntaxFromConnectionString(String connectionString) {
     String dbName = connectionString.split(":")[1];
-    
+
     SqlSyntax syntax = SqlSyntaxList.getSyntaxFor(dbName);
     if (syntax == null) {
       dbName = connectionString.split(":")[0];

--- a/src/main/java/org/verdictdb/sqlsyntax/SqliteSyntax.java
+++ b/src/main/java/org/verdictdb/sqlsyntax/SqliteSyntax.java
@@ -49,6 +49,12 @@ public class SqliteSyntax extends SqlSyntax {
   }
 
   @Override
+  public String getColumnsCommand(String catalog, String schema, String table) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
   public int getColumnTypeColumnIndex() {
     // TODO Auto-generated method stub
     return 0;

--- a/src/main/java/org/verdictdb/sqlwriter/SelectQueryToSql.java
+++ b/src/main/java/org/verdictdb/sqlwriter/SelectQueryToSql.java
@@ -16,25 +16,9 @@
 
 package org.verdictdb.sqlwriter;
 
-import java.util.List;
-import java.util.Set;
-
-import org.verdictdb.core.sqlobject.AbstractRelation;
-import org.verdictdb.core.sqlobject.AliasReference;
-import org.verdictdb.core.sqlobject.AliasedColumn;
-import org.verdictdb.core.sqlobject.AsteriskColumn;
-import org.verdictdb.core.sqlobject.BaseColumn;
-import org.verdictdb.core.sqlobject.BaseTable;
-import org.verdictdb.core.sqlobject.ColumnOp;
-import org.verdictdb.core.sqlobject.ConstantColumn;
-import org.verdictdb.core.sqlobject.GroupingAttribute;
-import org.verdictdb.core.sqlobject.JoinTable;
-import org.verdictdb.core.sqlobject.OrderbyAttribute;
-import org.verdictdb.core.sqlobject.SelectItem;
-import org.verdictdb.core.sqlobject.SelectQuery;
-import org.verdictdb.core.sqlobject.SetOperationRelation;
-import org.verdictdb.core.sqlobject.SubqueryColumn;
-import org.verdictdb.core.sqlobject.UnnamedColumn;
+import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
+import org.verdictdb.core.sqlobject.*;
 import org.verdictdb.exception.VerdictDBException;
 import org.verdictdb.exception.VerdictDBTypeException;
 import org.verdictdb.exception.VerdictDBValueException;
@@ -43,8 +27,8 @@ import org.verdictdb.sqlsyntax.PostgresqlSyntax;
 import org.verdictdb.sqlsyntax.PrestoHiveSyntax;
 import org.verdictdb.sqlsyntax.SqlSyntax;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Set;
 
 public class SelectQueryToSql {
 
@@ -121,9 +105,7 @@ public class SelectQueryToSql {
       return ((ConstantColumn) column).getValue().toString();
     } else if (column instanceof AsteriskColumn) {
       return "*";
-    } 
-    
-    else if (column instanceof ColumnOp) {
+    } else if (column instanceof ColumnOp) {
       ColumnOp columnOp = (ColumnOp) column;
       if (columnOp.getOpType().equals("avg")) {
         return "avg(" + unnamedColumnToSqlPart(columnOp.getOperand()) + ")";
@@ -503,7 +485,16 @@ public class SelectQueryToSql {
       if (base.getSchemaName().isEmpty()) {
         sql.append(quoteName(base.getTableName()));
       } else {
-        sql.append(quoteName(base.getSchemaName()) + "." + quoteName(base.getTableName()));
+        if (base.getCatalogName() == null || base.getCatalogName().isEmpty()) {
+          sql.append(quoteName(base.getSchemaName()) + "." + quoteName(base.getTableName()));
+        } else {
+          sql.append(
+              quoteName(base.getCatalogName())
+                  + "."
+                  + quoteName(base.getSchemaName())
+                  + "."
+                  + quoteName(base.getTableName()));
+        }
       }
       if (base.getAliasName().isPresent()) {
         sql.append(" as " + base.getAliasName().get());

--- a/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
+++ b/src/test/java/org/verdictdb/coordinator/CreateScrambleTableFromSqlTest.java
@@ -40,8 +40,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class CreateScrambleTableFromSqlTest {
 
-  // Disabled redshift test due to unavailable test instance
-  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  // Disabled impala, redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "postgresql"};
   //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
   //  private static final String[] targetDatabases = {"mysql"};
 
@@ -72,8 +72,8 @@ public class CreateScrambleTableFromSqlTest {
     options.setVerdictTempSchemaName(TEMP_SCHEMA_NAME);
     options.setVerdictMetaSchemaName(TEMP_SCHEMA_NAME);
     setupMysql();
-    setupImpala();
-    // Disabled redshift test due to unavailable test instance
+    // Disabled impala + redshift test due to unavailable test instance
+    //    setupImpala();
     //    setupRedshift();
     setupPostgresql();
   }

--- a/src/test/java/org/verdictdb/coordinator/PrestoHashScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/PrestoHashScramblingCoordinatorTest.java
@@ -1,15 +1,5 @@
 package org.verdictdb.coordinator;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.AfterClass;
@@ -23,6 +13,16 @@ import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.connection.JdbcConnection;
 import org.verdictdb.exception.VerdictDBDbmsException;
 import org.verdictdb.exception.VerdictDBException;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 @Category(PrestoTests.class)
 public class PrestoHashScramblingCoordinatorTest {
@@ -38,32 +38,56 @@ public class PrestoHashScramblingCoordinatorTest {
   private static final String PRESTO_USER;
 
   private static final String PRESTO_PASSWORD;
-  
+
   private static final String PRESTO_SCHEMA =
       "coordinator_test_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
 
   static {
-    PRESTO_HOST = System.getenv("VERDICTDB_TEST_PRESTO_HOST");
-    PRESTO_CATALOG = System.getenv("VERDICTDB_TEST_PRESTO_CATALOG");
-    PRESTO_USER = System.getenv("VERDICTDB_TEST_PRESTO_USER");
-    PRESTO_PASSWORD = System.getenv("VERDICTDB_TEST_PRESTO_PASSWORD");
+    PRESTO_HOST = "localhost:8080";
+    PRESTO_CATALOG = "memory";
+    PRESTO_USER = "root";
+    PRESTO_PASSWORD = "";
+    //    PRESTO_HOST = System.getenv("VERDICTDB_TEST_PRESTO_HOST");
+    //    PRESTO_CATALOG = System.getenv("VERDICTDB_TEST_PRESTO_CATALOG");
+    //    PRESTO_USER = System.getenv("VERDICTDB_TEST_PRESTO_USER");
+    //    PRESTO_PASSWORD = System.getenv("VERDICTDB_TEST_PRESTO_PASSWORD");
   }
 
   @BeforeClass
-  public static void setupPrestoDatabase() throws SQLException, VerdictDBDbmsException, IOException {
-    String prestoConnectionString =
-        String.format("jdbc:presto://%s/%s/default", PRESTO_HOST, PRESTO_CATALOG);
-    prestoConn = 
-        DatabaseConnectionHelpers.setupPresto(
+  public static void setupPrestoDatabase()
+      throws SQLException, VerdictDBDbmsException, IOException {
+    //    String prestoConnectionString =
+    //        String.format("jdbc:presto://%s/%s/default", PRESTO_HOST, PRESTO_CATALOG);
+    String prestoConnectionString = String.format("jdbc:presto://%s/memory", PRESTO_HOST);
+
+    // Clean leftover schemas
+    Connection conn = DriverManager.getConnection(prestoConnectionString, "root", "");
+    ResultSet rs = conn.createStatement().executeQuery("SHOW SCHEMAS IN memory");
+    while (rs.next()) {
+      String schema = rs.getString(1);
+      if (!schema.equalsIgnoreCase(PRESTO_SCHEMA) && schema.startsWith("coordinator_test_")) {
+        ResultSet rs2 =
+            conn.createStatement().executeQuery(String.format("SHOW TABLES IN memory.%s", schema));
+        while (rs2.next()) {
+          String table = rs2.getString(1);
+          conn.createStatement().execute(String.format("DROP TABLE memory.%s.%s", schema, table));
+        }
+        conn.createStatement().execute(String.format("DROP SCHEMA IF EXISTS memory.%s", schema));
+      }
+    }
+
+    prestoConn =
+        DatabaseConnectionHelpers.setupPrestoInMemory(
             prestoConnectionString, PRESTO_USER, PRESTO_PASSWORD, PRESTO_SCHEMA);
     prestoStmt = prestoConn.createStatement();
   }
-  
+
   @AfterClass
   public static void tearDown() throws SQLException {
     ResultSet rs = prestoStmt.executeQuery(String.format("SHOW TABLES IN %s", PRESTO_SCHEMA));
     while (rs.next()) {
-      prestoStmt.execute(String.format("DROP TABLE IF EXISTS %s.%s", PRESTO_SCHEMA, rs.getString(1)));
+      prestoStmt.execute(
+          String.format("DROP TABLE IF EXISTS %s.%s", PRESTO_SCHEMA, rs.getString(1)));
     }
     rs.close();
     prestoStmt.execute(String.format("DROP SCHEMA IF EXISTS %s", PRESTO_SCHEMA));
@@ -74,8 +98,8 @@ public class PrestoHashScramblingCoordinatorTest {
   @Test
   public void sanityCheck() throws VerdictDBDbmsException {
     DbmsConnection conn = JdbcConnection.create(prestoConn);
-    DbmsQueryResult result = conn.execute(
-        String.format("select * from %s.lineitem", PRESTO_SCHEMA));
+    DbmsQueryResult result =
+        conn.execute(String.format("select * from %s.lineitem", PRESTO_SCHEMA));
     int rowCount = 0;
     while (result.next()) {
       rowCount++;
@@ -93,13 +117,14 @@ public class PrestoHashScramblingCoordinatorTest {
     testScramblingCoordinator("orders", "o_orderkey");
   }
 
-  public void testScramblingCoordinator(String tablename, String columnname) throws VerdictDBException {
+  public void testScramblingCoordinator(String tablename, String columnname)
+      throws VerdictDBException {
     DbmsConnection conn = JdbcConnection.create(prestoConn);
 
     String scrambleSchema = PRESTO_SCHEMA;
     String scratchpadSchema = PRESTO_SCHEMA;
     long blockSize = 100;
-    ScramblingCoordinator scrambler = 
+    ScramblingCoordinator scrambler =
         new ScramblingCoordinator(conn, scrambleSchema, scratchpadSchema, blockSize);
 
     // perform scrambling
@@ -117,26 +142,27 @@ public class PrestoHashScramblingCoordinatorTest {
       assertEquals(originalColumns.get(i).getLeft(), columns.get(i).getLeft());
       assertEquals(originalColumns.get(i).getRight(), columns.get(i).getRight());
     }
-    assertEquals(originalColumns.size()+2, columns.size());
+    assertEquals(originalColumns.size() + 2, columns.size());
 
     List<String> partitions = conn.getPartitionColumns(PRESTO_SCHEMA, scrambledTable);
-    assertEquals(Arrays.asList("verdictdbblock"), partitions);
+    // This is invalid with 'memory' catalog
+    //    assertEquals(Arrays.asList("verdictdbblock"), partitions);
 
-    DbmsQueryResult result1 = 
+    DbmsQueryResult result1 =
         conn.execute(String.format("select count(*) from %s.%s", PRESTO_SCHEMA, originalTable));
-    DbmsQueryResult result2 = 
+    DbmsQueryResult result2 =
         conn.execute(String.format("select count(*) from %s.%s", PRESTO_SCHEMA, scrambledTable));
     result1.next();
     result2.next();
     assertEquals(result1.getInt(0), result2.getInt(0));
 
-    DbmsQueryResult result = 
+    DbmsQueryResult result =
         conn.execute(
-            String.format("select min(verdictdbblock), max(verdictdbblock) from %s.%s", 
+            String.format(
+                "select min(verdictdbblock), max(verdictdbblock) from %s.%s",
                 PRESTO_SCHEMA, scrambledTable));
     result.next();
     assertEquals(0, result.getInt(0));
     assertEquals((int) Math.ceil(result2.getInt(0) / (float) blockSize) - 1, result.getInt(1));
   }
-
 }

--- a/src/test/java/org/verdictdb/coordinator/PrestoHashScramblingCoordinatorTest.java
+++ b/src/test/java/org/verdictdb/coordinator/PrestoHashScramblingCoordinatorTest.java
@@ -84,13 +84,16 @@ public class PrestoHashScramblingCoordinatorTest {
 
   @AfterClass
   public static void tearDown() throws SQLException {
-    ResultSet rs = prestoStmt.executeQuery(String.format("SHOW TABLES IN %s", PRESTO_SCHEMA));
+    ResultSet rs =
+        prestoConn
+            .createStatement()
+            .executeQuery(String.format("SHOW TABLES IN memory.%s", PRESTO_SCHEMA));
     while (rs.next()) {
       prestoStmt.execute(
-          String.format("DROP TABLE IF EXISTS %s.%s", PRESTO_SCHEMA, rs.getString(1)));
+          String.format("DROP TABLE IF EXISTS memory.%s.%s", PRESTO_SCHEMA, rs.getString(1)));
     }
     rs.close();
-    prestoStmt.execute(String.format("DROP SCHEMA IF EXISTS %s", PRESTO_SCHEMA));
+    prestoStmt.execute(String.format("DROP SCHEMA IF EXISTS memory.%s", PRESTO_SCHEMA));
     prestoStmt.close();
     prestoConn.close();
   }

--- a/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcCommonQueryForAllDatabasesTest.java
@@ -121,8 +121,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
     options.setVerdictMetaSchemaName(VERDICT_META_SCHEMA);
     options.setVerdictTempSchemaName(VERDICT_TEMP_SCHEMA);
     setupMysql();
-    setupImpala();
-    // Disabled redshift test due to unavailable test instance
+    // Disabled impala, redshift test due to unavailable test instance
+    //    setupImpala();
     //    setupRedshift();
     setupPostgresql();
   }
@@ -145,8 +145,8 @@ public class JdbcCommonQueryForAllDatabasesTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> databases() {
-    // Disabled redshift test due to unavailable test instance
-    return Arrays.asList("mysql", "impala", "postgresql");
+    // Disabled impala, redshift test due to unavailable test instance
+    return Arrays.asList("mysql", "postgresql");
     //    return Arrays.asList("mysql", "impala", "redshift", "postgresql");
   }
 

--- a/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/JdbcQueryDataTypeForAllDatabasesTest.java
@@ -39,8 +39,8 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
 
   private String database;
 
-  // Disabled redshift test due to unavailable test instance
-  private static final String[] targetDatabases = {"mysql", "impala", "postgresql"};
+  // Disabled impala, redshift test due to unavailable test instance
+  private static final String[] targetDatabases = {"mysql", "postgresql"};
   //  private static final String[] targetDatabases = {"mysql", "impala", "redshift", "postgresql"};
 
   public JdbcQueryDataTypeForAllDatabasesTest(String database) {
@@ -139,9 +139,9 @@ public class JdbcQueryDataTypeForAllDatabasesTest {
   public static void tearDown() throws SQLException {
     tearDownMysql();
     tearDownPostgresql();
-    // Disabled redshift test due to unavailable test instance
+    // Disabled impala, redshift test due to unavailable test instance
     //    tearDownRedshift();
-    tearDownImpala();
+    //    tearDownImpala();
   }
 
   @Parameterized.Parameters(name = "{0}")

--- a/src/test/resources/tpch_test_query/presto/query1.sql
+++ b/src/test/resources/tpch_test_query/presto/query1.sql
@@ -11,7 +11,7 @@ select
     count(*) as count_order
 from  lineitem
 where
-    date(l_shipdate) <= date '1998-12-01'
+    l_shipdate <= date '1998-12-01'
 group by
     l_returnflag,
     l_linestatus

--- a/src/test/resources/tpch_test_query/presto/query3.sql
+++ b/src/test/resources/tpch_test_query/presto/query3.sql
@@ -9,8 +9,8 @@ from
 where
     c_custkey = o_custkey
     and l_orderkey = o_orderkey
-    and date(o_orderdate) < date '1998-12-01'
-    and date(l_shipdate) > date '1996-12-01'
+    and o_orderdate < date '1998-12-01'
+    and l_shipdate > date '1996-12-01'
 group by
     l_orderkey,
     o_orderdate,

--- a/src/test/resources/tpch_test_query/presto/query6.sql
+++ b/src/test/resources/tpch_test_query/presto/query6.sql
@@ -2,8 +2,8 @@ select
     sum(l_extendedprice * l_discount) as revenue
     from lineitem
 where
-    date(l_shipdate) >= date '1992-12-01'
-    and date(l_shipdate) < date '1998-12-01'
+    l_shipdate >= date '1992-12-01'
+    and l_shipdate < date '1998-12-01'
     and l_discount between 0.04 - 0.02
     and 0.04 + 0.02
     and l_quantity < 15

--- a/src/test/resources/tpch_test_query/presto_new/query1.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query1.sql
@@ -1,0 +1,20 @@
+select
+    returnflag,
+    linestatus,
+    sum(quantity) as sum_qty,
+    sum(extendedprice) as sum_base_price,
+    sum(extendedprice * (1 - discount)) as sum_disc_price,
+    sum(extendedprice * (1 - discount) * (1 + tax)) as sum_charge,
+    avg(quantity) as avg_qty,
+    avg(extendedprice) as avg_price,
+    avg(discount) as avg_disc,
+    count(*) as count_order
+from  SCRAMBLE_SCHEMA.lineitem
+where
+    shipdate <= date '1998-12-01'
+group by
+    returnflag,
+    linestatus
+order by
+    returnflag,
+    linestatus

--- a/src/test/resources/tpch_test_query/presto_new/query10.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query10.sql
@@ -1,0 +1,31 @@
+select
+    c.custkey,
+    c."name",
+    sum(l.extendedprice * (1 - l.discount)) as revenue,
+    c.acctbal,
+--    n."name",
+    c.address,
+    c.phone,
+    c."comment"
+from
+    TPCH_SCHEMA.customer c,
+    SCRAMBLE_SCHEMA.orders o,
+    SCRAMBLE_SCHEMA.lineitem l,
+    TPCH_SCHEMA.nation n
+where
+    c.custkey = o.custkey
+    and l.orderkey = o.orderkey
+    and o.orderdate >= date '1992-01-01'
+    and o.orderdate < date '1998-01-01'
+    and l.returnflag = 'R'
+    and c.nationkey = n.nationkey
+group by
+    c.custkey,
+    c."name",
+    c.acctbal,
+    c.phone,
+--    n."name", commented out until #375 is fixed
+    c.address,
+    c."comment"
+order by
+    revenue desc

--- a/src/test/resources/tpch_test_query/presto_new/query100.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query100.sql
@@ -1,0 +1,15 @@
+-- This is an additional query used for testing count-distinct aggregation.
+select
+    l.returnflag,
+    l.linestatus,
+    count(distinct l.orderkey) as distinct_key
+from  SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate <= date '1998-12-01'
+group by
+    l.returnflag,
+    l.linestatus
+order by
+    l.returnflag,
+    l.linestatus
+    

--- a/src/test/resources/tpch_test_query/presto_new/query101.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query101.sql
@@ -1,0 +1,7 @@
+-- This is an additional query used for testing count-distinct aggregation.
+select
+    cast(count(distinct l.orderkey) as int) as distinct_key
+from  SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate <= date '1998-12-01'
+    

--- a/src/test/resources/tpch_test_query/presto_new/query102.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query102.sql
@@ -1,0 +1,6 @@
+-- This is an additional query used for testing count-distinct aggregation.
+select
+    cast(count(distinct l.orderkey) * 10.1 as int) as distinct_key
+from  SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate <= date '1998-12-01'

--- a/src/test/resources/tpch_test_query/presto_new/query103.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query103.sql
@@ -1,0 +1,7 @@
+-- This is an additional query used for testing count-distinct aggregation.
+-- MySQL use SIGNED/UNSIGNED instead of INT
+select
+    cast(approx_distinct(l.orderkey) * 10.1 as int) as distinct_key
+from  SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate <= date '1998-12-01'

--- a/src/test/resources/tpch_test_query/presto_new/query12.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query12.sql
@@ -1,0 +1,19 @@
+select
+    l.shipmode,
+    sum(case when o.orderpriority = '1-URGENT' or o.orderpriority = '2-HIGH'
+        then 1 else 0 end) as high_line_count,
+    sum(case when o.orderpriority <> '1-URGENT' and o.orderpriority <> '2-HIGH'
+        then 1 else 0 end) as low_line_count
+from
+    SCRAMBLE_SCHEMA.orders o,
+    SCRAMBLE_SCHEMA.lineitem l
+where
+    o.orderkey = l.orderkey
+    and l.commitdate < l.receiptdate
+    and l.shipdate < l.commitdate
+    and l.receiptdate >= date '1992-01-01'
+    and l.receiptdate < date '1998-01-01'
+group by
+    l.shipmode
+order by
+    l.shipmode

--- a/src/test/resources/tpch_test_query/presto_new/query13.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query13.sql
@@ -1,0 +1,11 @@
+select
+    c.custkey,
+    count(o.orderkey) as c_count
+from
+    TPCH_SCHEMA.customer c inner join SCRAMBLE_SCHEMA.orders o
+        on c.custkey = o.custkey
+        and o."comment" not like '%unusual%'
+group by
+    c.custkey
+order by
+    c.custkey

--- a/src/test/resources/tpch_test_query/presto_new/query14.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query14.sql
@@ -1,0 +1,11 @@
+select
+    100.00 * sum(case when p."type" like 'PROMO%' then l.extendedprice * (1 - l.discount)
+        else 0 end) as numerator,
+    sum(l.extendedprice * (1 - l.discount)) as denominator
+from
+    SCRAMBLE_SCHEMA.lineitem l,
+    TPCH_SCHEMA.part p
+where
+    l.partkey = p.partkey
+    and l.shipdate >= date '1992-01-01'
+    and l.shipdate < date '1998-01-01'

--- a/src/test/resources/tpch_test_query/presto_new/query15.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query15.sql
@@ -1,0 +1,12 @@
+select
+    l.suppkey,
+    sum(l.extendedprice * (1 - l.discount))
+from
+    SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate >= date '1992-01-01'
+    and l.shipdate < date '1999-01-01'
+group by
+    l.suppkey
+order by
+    l.suppkey

--- a/src/test/resources/tpch_test_query/presto_new/query17.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query17.sql
@@ -1,0 +1,26 @@
+select
+  sum(extendedprice) / 7.0 as avg_yearly
+from (
+  select
+    quantity as quantity,
+    extendedprice as extendedprice,
+    t_avg_quantity
+  from
+    (select
+  l.partkey as t_partkey,
+  0.2 * avg(l.quantity) as t_avg_quantity
+from
+  SCRAMBLE_SCHEMA.lineitem l
+group by l.partkey) as q17_lineitem_tmp_cached Inner Join
+    (select
+      l.quantity,
+      l.partkey,
+      l.extendedprice
+    from
+      TPCH_SCHEMA.part p,
+      SCRAMBLE_SCHEMA.lineitem l
+    where
+      p.partkey = l.partkey
+    ) as l1 on l1.partkey = t_partkey
+) a
+where quantity > t_avg_quantity

--- a/src/test/resources/tpch_test_query/presto_new/query18.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query18.sql
@@ -1,0 +1,34 @@
+select
+  c."name",
+  c.custkey,
+  o.orderkey,
+  o.orderdate,
+  o.totalprice,
+  sum(l.quantity)
+from
+  TPCH_SCHEMA.customer c,
+  SCRAMBLE_SCHEMA.orders o,
+  (select
+  l1.orderkey,
+  sum(l1.quantity) as t_sum_quantity
+  from
+    SCRAMBLE_SCHEMA.lineitem l1
+  where
+    l1.orderkey is not null
+  group by
+    l1.orderkey) as t,
+  SCRAMBLE_SCHEMA.lineitem l
+where
+  c.custkey = o.custkey
+  and o.orderkey = t.orderkey
+  and o.orderkey is not null
+  and t.t_sum_quantity > 150
+group by
+  c."name",
+  c.custkey,
+  o.orderkey,
+  o.orderdate,
+  o.totalprice
+order by
+  o.totalprice desc,
+  o.orderdate

--- a/src/test/resources/tpch_test_query/presto_new/query19.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query19.sql
@@ -1,0 +1,27 @@
+select
+    sum(l.extendedprice* (1 - l.discount)) as revenue
+from
+    SCRAMBLE_SCHEMA.lineitem l,
+    TPCH_SCHEMA.part p
+where
+    ( p.partkey = l.partkey
+    and p.container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+    and l.quantity >= 4
+    and l.quantity <= 4 + 10
+    and p."size" between 1 and 5
+    and l.shipmode in ('AIR', 'AIR REG')
+    and l.shipinstruct = 'DELIVER IN PERSON' )
+or ( p.partkey = l.partkey
+    and p.container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+    and l.quantity >= 5
+    and l.quantity <= 5 + 10
+    and p."size" between 1 and 10
+    and l.shipmode in ('AIR', 'AIR REG')
+    and l.shipinstruct = 'DELIVER IN PERSON' )
+or ( p.partkey = l.partkey
+    and p.container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+    and l.quantity >= 6
+    and l.quantity <= 6 + 10
+    and p."size" between 1 and 15
+    and l.shipmode in ('AIR', 'AIR REG')
+    and l.shipinstruct = 'DELIVER IN PERSON' )

--- a/src/test/resources/tpch_test_query/presto_new/query20.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query20.sql
@@ -1,0 +1,23 @@
+select
+  s."name",
+  count(s.address)
+from
+  TPCH_SCHEMA.supplier s,
+  TPCH_SCHEMA.nation n,
+  TPCH_SCHEMA.partsupp ps,
+  (select
+    l.partkey,
+    l.suppkey,
+    0.5 * sum(l.quantity) as sum_quantity
+  from
+    SCRAMBLE_SCHEMA.lineitem l
+where
+  l.shipdate >= date '1994-01-01'
+  and l.shipdate < date '1998-01-01'
+group by l.partkey, l.suppkey) as q20_tmp2_cached
+where
+  s.nationkey = n.nationkey
+  and n."name" = 'CANADA'
+  and s.suppkey = ps.suppkey
+  group by s."name"
+order by s."name"

--- a/src/test/resources/tpch_test_query/presto_new/query21.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query21.sql
@@ -1,0 +1,27 @@
+select s_name, count(1) as numwait
+from (  select s_name   from (    select s_name, t2.orderkey, l_suppkey, countsuppkey, maxsuppkey
+    from (      select l.orderkey, count(l.suppkey) countsuppkey, max(l.suppkey) as maxsuppkey
+      from SCRAMBLE_SCHEMA.lineitem l
+      where l.receiptdate > l.commitdate and l.orderkey is not null
+      group by l.orderkey) as t2    right outer join (select  s_name, l_orderkey, l_suppkey  from
+      (select s_name, t1.orderkey as l_orderkey, l2.suppkey as l_suppkey, countsuppkey, maxsuppkey
+       from
+         (select l.orderkey, count(l.suppkey) as countsuppkey, max(l.suppkey) as maxsuppkey
+          from SCRAMBLE_SCHEMA.lineitem l
+          where l.orderkey is not null
+          group by l.orderkey) as t1
+          join
+          (select s_name, l1.orderkey, l1.suppkey
+           from SCRAMBLE_SCHEMA.orders o
+           join (select s."name" as s_name, l.orderkey, l.suppkey
+                 from TPCH_SCHEMA.nation n join TPCH_SCHEMA.supplier s on s.nationkey = n.nationkey
+                                           join SCRAMBLE_SCHEMA.lineitem l on s.suppkey = l.suppkey
+                 where l.receiptdate > l.commitdate
+                 and l.orderkey is not null) l1 on o.orderkey = l1.orderkey
+          ) l2 on l2.orderkey = t1.orderkey
+        ) a
+      where (countsuppkey > 1) or ((countsuppkey=1) and (l_suppkey <> maxsuppkey))
+    ) l3 on l_orderkey = t2.orderkey
+  ) b
+  where (countsuppkey is null) or ((countsuppkey=1) and (l_suppkey = maxsuppkey))
+) c group by s_name order by numwait desc, s_name

--- a/src/test/resources/tpch_test_query/presto_new/query3.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query3.sql
@@ -1,0 +1,21 @@
+select
+    o.orderkey,
+    sum(extendedprice * (1 - discount)) as revenue,
+    orderdate, shippriority
+from
+    TPCH_SCHEMA.customer c,
+    SCRAMBLE_SCHEMA.orders o,
+    SCRAMBLE_SCHEMA.lineitem l
+where
+    c.custkey = o.custkey
+    and o.orderkey = l.orderkey
+    and orderdate < date '1998-12-01'
+    and shipdate > date '1996-12-01'
+group by
+    o.orderkey,
+    o.orderdate,
+    shippriority
+order by
+    revenue desc,
+    orderdate
+limit 10

--- a/src/test/resources/tpch_test_query/presto_new/query4.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query4.sql
@@ -1,0 +1,14 @@
+select
+    orderpriority,
+    count(*) as order_count
+from
+    SCRAMBLE_SCHEMA.orders o join SCRAMBLE_SCHEMA.lineitem l
+        on l.orderkey = o.orderkey
+where
+    o.orderdate >= date '1992-12-01'
+    and o.orderdate < date '1998-12-01'
+    and l.commitdate < l.receiptdate
+group by
+    orderpriority
+order by
+    orderpriority

--- a/src/test/resources/tpch_test_query/presto_new/query5.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query5.sql
@@ -1,0 +1,23 @@
+select
+    n."name",
+    sum(l.extendedprice * (1 - l.discount)) as revenue
+from
+    TPCH_SCHEMA.customer c,
+    SCRAMBLE_SCHEMA.orders o,
+    SCRAMBLE_SCHEMA.lineitem l,
+    TPCH_SCHEMA.supplier s,
+    TPCH_SCHEMA.nation n,
+    TPCH_SCHEMA.region r
+where
+    c.custkey = o.custkey
+    and l.orderkey = o.orderkey
+    and l.suppkey = s.suppkey
+    and c.nationkey = s.nationkey
+    and s.nationkey = n.nationkey
+    and n.regionkey = r.regionkey
+    and o.orderdate >= date '1992-12-01'
+    and o.orderdate < date '1998-12-01'
+group by
+    n."name"
+order by
+    revenue desc

--- a/src/test/resources/tpch_test_query/presto_new/query6.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query6.sql
@@ -1,0 +1,9 @@
+select
+    sum(l.extendedprice * l.discount) as revenue
+    from SCRAMBLE_SCHEMA.lineitem l
+where
+    l.shipdate >= date '1992-12-01'
+    and l.shipdate < date '1998-12-01'
+    and l.discount between 0.04 - 0.02
+    and 0.04 + 0.02
+    and l.quantity < 15

--- a/src/test/resources/tpch_test_query/presto_new/query7.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query7.sql
@@ -1,0 +1,36 @@
+select
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) as revenue
+from (
+    select
+        n1."name" as supp_nation,
+        n2."name" as cust_nation,
+        date_format(l.shipdate, '%Y') as l_year,
+        l.extendedprice * (1 - l.discount) as volume
+    from
+        TPCH_SCHEMA.supplier s,
+        SCRAMBLE_SCHEMA.lineitem l,
+        SCRAMBLE_SCHEMA.orders o,
+        TPCH_SCHEMA.customer c,
+        TPCH_SCHEMA.nation n1,
+        TPCH_SCHEMA.nation n2
+    where
+        s.suppkey = l.suppkey
+        and o.orderkey = l.orderkey
+        and c.custkey = o.custkey
+        and s.nationkey = n1.nationkey
+        and c.nationkey = n2.nationkey
+        and ( (n1."name" = 'CHINA' and n2."name" = 'RUSSIA')
+            or (n1."name" = 'RUSSIA' and n2."name" = 'CHINA') )
+        and l.shipdate between (timestamp '1992-01-01') and (timestamp '1996-12-31') )
+    as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year

--- a/src/test/resources/tpch_test_query/presto_new/query8.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query8.sql
@@ -1,0 +1,28 @@
+select
+  o_year,
+  sum(case
+    when nation = 'PERU' then volume
+    else 0
+  end) as numerator, sum(volume) as demoninator
+from
+  (
+    select
+      date_format(o.orderdate, '%Y') as o_year,
+      l.extendedprice * (1 - l.discount) as volume,
+      n2."name" as nation
+    from
+      SCRAMBLE_SCHEMA.lineitem l join SCRAMBLE_SCHEMA.orders o on l.orderkey = o.orderkey
+      join TPCH_SCHEMA.supplier s on s.suppkey = l.suppkey
+      join TPCH_SCHEMA.part p on p.partkey = l.partkey
+      join TPCH_SCHEMA.customer c on o.custkey = c.custkey
+      join TPCH_SCHEMA.nation n1 on c.nationkey = n1.nationkey
+      join TPCH_SCHEMA.region r on n1.regionkey = r.regionkey
+      join TPCH_SCHEMA.nation n2 on s.nationkey = n2.nationkey
+    where
+      r."name" = 'AMERICA'
+      and o.orderdate between date '1995-01-01' and date '1996-12-31'
+      and p."type" = 'ECONOMY ANODIZED STEEL'  ) as all_nations
+group by
+  o_year
+order by
+  o_year

--- a/src/test/resources/tpch_test_query/presto_new/query9.sql
+++ b/src/test/resources/tpch_test_query/presto_new/query9.sql
@@ -1,0 +1,25 @@
+select
+  nation,
+  o_year,
+  sum(amount) as sum_profit
+from
+  (
+    select
+      n."name" as nation,
+      date_format(o.orderdate, '%Y') as o_year,
+      l.extendedprice * (1 - l.discount) - ps.supplycost * l.quantity as amount
+    from
+      SCRAMBLE_SCHEMA.lineitem l join SCRAMBLE_SCHEMA.orders o on o.orderkey = l.orderkey
+      join TPCH_SCHEMA.partsupp ps on ps.suppkey = l.suppkey and ps.partkey = l.partkey
+      join TPCH_SCHEMA.supplier s on s.suppkey = l.suppkey
+      join TPCH_SCHEMA.part p on p.partkey = l.partkey
+      join TPCH_SCHEMA.nation n on s.nationkey = n.nationkey
+    where
+      p."name" like '%green%'
+  ) as profit
+group by
+  nation,
+  o_year
+order by
+  nation,
+  o_year desc


### PR DESCRIPTION
This PR makes Presto unit tests to run locally on `starburstdata/presto` docker image in build-jdk8.

The original plan was to use `tpch.tiny` schema (because even `tpch.sf1` was too big) for tpch queries, but it turned out that it was also too big for our CircleCI instances as Presto docker container died with exit code 137, meaning it was likely died due to OOM -- as it now uses `memory` catalog, creating scrambles in the memory during the tests --, while it worked fine locally on my machine.

Therefore, I had to go back to the existing way of populating tpch data manually as before in `memory` catalog. I had to change some parameters in CircleCI config for build-jdk8 as the container still went OOM and died during the test. Now it seems to work except that it fails on some Impala tests, which has nothing to do with this PR and it just looks like our Impala test instance is not operational currently.

Overall, it took some time for me to implement the 'original plan' that I had, but I had to go back to previous method, which made many of changes that I had made unnecessary :(

Nonetheless, the changes include:

- Fix build-jdk8 config for memory tweaks and also running presto docker container
- Support for optional **catalog.schema.table** format for table reference
- Add `PrestoMemorySyntax` for unit tests: 'memory' catalog does not support a few syntax that works for other catalogs (e.g., parititon_by)
- Add 'SetupPrestoInMemory' and other related methods to create tpch test data in 'memory' catalog
- New tpch query templates for `tpch.tiny` in the `presto_new` directory (ended up not using them though)
- Fix few queries in previous presto tpch queries (basically removed date function)