### PR TITLE
Add support for REGEXP_LIKE as predicates

### DIFF
--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -729,7 +729,7 @@ unary_predicate_function
 
 binary_predicate_function
     : NOT? function_name = (ST_CONTAINS | ST_CROSSES | ST_DISJOINT | ST_EQUALS | ST_INTERSECTS
-    | ST_OVERLAPS | ST_RELATE | ST_TOUCHES | ST_WITHIN)
+    | ST_OVERLAPS | ST_RELATE | ST_TOUCHES | ST_WITHIN | REGEXP_LIKE)
       '(' expression ',' expression ')'
     ;
 

--- a/src/test/java/org/verdictdb/jdbc41/PrestoFunctionTest.java
+++ b/src/test/java/org/verdictdb/jdbc41/PrestoFunctionTest.java
@@ -94,6 +94,18 @@ public class PrestoFunctionTest {
   }
 
   @Test
+  public void runRegexLike1Test() throws SQLException {
+    String sql;
+    ResultSet rs;
+
+    sql =
+        String.format("SELECT * from tpch.tiny.customer WHERE regexp_like('1a 2b 14m', '\\\\d+b')");
+    rs = vc.createStatement().executeQuery(sql);
+
+    rs.close();
+  }
+
+  @Test
   public void runRegexFunctionsTest() throws SQLException {
     String sql;
     ResultSet rs;


### PR DESCRIPTION
Resolves #377.

Fix the issue where REGEXP_LIKE in WHERE clause not working correctly.